### PR TITLE
Add basic documentation + small fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,5 +6,7 @@ ssapy/data/de430.bsp filter=lfs diff=lfs merge=lfs -text
 ssapy/data/gggrx_1200a_sha.lbl filter=lfs diff=lfs merge=lfs -text
 ssapy/data/gggrx_1200a_sha.tab filter=lfs diff=lfs merge=lfs -text
 ssapy/data/moon_pa_de440_200625.bpc filter=lfs diff=lfs merge=lfs -text
+*.bsp filter=lfs diff=lfs merge=lfs -text
+*.egm.cof filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,5 @@ ssapy/data/de430.bsp filter=lfs diff=lfs merge=lfs -text
 ssapy/data/gggrx_1200a_sha.lbl filter=lfs diff=lfs merge=lfs -text
 ssapy/data/gggrx_1200a_sha.tab filter=lfs diff=lfs merge=lfs -text
 ssapy/data/moon_pa_de440_200625.bpc filter=lfs diff=lfs merge=lfs -text
-*.bsp filter=lfs diff=lfs merge=lfs -text
-*.egm.cof filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ cover/
 
 # Sphinx documentation
 docs/_build/
+docs/source/api
+docs/source/modules
 
 # Jupyter Notebook
 **/*.ipynb_checkpoints

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -16,4 +16,7 @@ Then, to build the HTML documentation locally, from the `docs` directory, run
 
 Then open `_build/html/index.html` to browse the docs locally.
 
+Alternatively, you can run `sphinx-autobuild . _build/html` to start a server that watches for changes in `/docs`
+and regenerates the HTML docs automatically while serving them at http://127.0.0.1:8000/.
+
 Note that if you updated docstrings, you'll need to re-build and re-install ssapy before re-building the docs.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,0 +1,19 @@
+SSAPy Documentation
+===================
+
+Building the docs
+-----------------
+
+First, build and _install_ `ssapy` following the `Installing SSAPy <https://LLNL.github.io/SSAPy/installation.html>`_ section of the documentation.
+
+Then, to build the HTML documentation locally, from the `docs` directory, run
+
+.. code-block:: bash
+
+    make html
+
+(run it twice to generate all files.)
+
+Then open `_build/html/index.html` to browse the docs locally.
+
+Note that if you updated docstrings, you'll need to re-build and re-install ssapy before re-building the docs.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -34,7 +34,7 @@ These requirements can be easily installed on most modern macOS and Linux system
        .. code-block:: console
 
           brew update
-          brew install gcc git git-lfs python3 svn graphviz
+          brew install gcc git git-lfs python3 graphviz
 
 Installation
 ------------

--- a/ssapy/accel.py
+++ b/ssapy/accel.py
@@ -1,3 +1,7 @@
+"""
+Classes for modeling accelerations.
+"""
+
 import numpy as np
 
 from . import _ssapy
@@ -101,6 +105,7 @@ class AccelSum(Accel):
 
 
 class AccelProd(Accel):
+    """Acceleration defined as the product of an acceleration with a constant factor."""
     def __init__(self, accel, factor):
         super().__init__()
         self.accel = accel

--- a/ssapy/body.py
+++ b/ssapy/body.py
@@ -107,7 +107,7 @@ class MoonPosition:
         from jplephem.spk import SPK
         from . import datadir
 
-        fn = os.path.join(datadir, "de430.bsp")  # https://naif.jpl.nasa.gov/pub/naif/LUCY/kernels/spk/de430s.bsp
+        fn = os.path.join(datadir, "de430.bsp")  # https://naif.jpl.nasa.gov/pub/naif/LUCY/kernels/spk/de430s.bsp.lbl
         self.kernel = SPK.open(fn)
 
     def __call__(self, t):
@@ -138,7 +138,7 @@ class SunPosition:
         from jplephem.spk import SPK
         from . import datadir
 
-        fn = os.path.join(datadir, "de430.bsp")  # https://naif.jpl.nasa.gov/pub/naif/LUCY/kernels/spk/de430s.bsp
+        fn = os.path.join(datadir, "de430.bsp")  # https://naif.jpl.nasa.gov/pub/naif/LUCY/kernels/spk/de430s.bsp.lbl
         self.kernel = SPK.open(fn)
 
     def __call__(self, t):

--- a/ssapy/body.py
+++ b/ssapy/body.py
@@ -1,3 +1,7 @@
+"""
+Classes representing celestial bodies.
+"""
+
 import erfa
 import numpy as np
 from .utils import _gpsToTT, iers_interp
@@ -103,7 +107,7 @@ class MoonPosition:
         from jplephem.spk import SPK
         from . import datadir
 
-        fn = os.path.join(datadir, "de430.bsp")  # https://naif.jpl.nasa.gov/pub/naif/LUCY/kernels/spk/de430s.bsp.lbl
+        fn = os.path.join(datadir, "de430.bsp")  # https://naif.jpl.nasa.gov/pub/naif/LUCY/kernels/spk/de430s.bsp
         self.kernel = SPK.open(fn)
 
     def __call__(self, t):
@@ -134,7 +138,7 @@ class SunPosition:
         from jplephem.spk import SPK
         from . import datadir
 
-        fn = os.path.join(datadir, "de430.bsp")  # https://naif.jpl.nasa.gov/pub/naif/LUCY/kernels/spk/de430s.bsp.lbl
+        fn = os.path.join(datadir, "de430.bsp")  # https://naif.jpl.nasa.gov/pub/naif/LUCY/kernels/spk/de430s.bsp
         self.kernel = SPK.open(fn)
 
     def __call__(self, t):

--- a/ssapy/constants.py
+++ b/ssapy/constants.py
@@ -1,3 +1,7 @@
+"""
+A collection of physical constants.
+"""
+
 import numpy as np
 
 # GM

--- a/ssapy/correlate_tracks.py
+++ b/ssapy/correlate_tracks.py
@@ -2012,7 +2012,7 @@ def summarize_tracklet(arc):
     pmra, pmdec: the proper motion in right ascension and declination
     dpmra, dpmdec: the uncertainty in the proper motion in RA and declination
     """
-    unit = ssapy.utils.lb2unit(arc['ra'].to(u.rad).value,
+    unit = ssapy.utils.lb_to_unit(arc['ra'].to(u.rad).value,
                                arc['dec'].to(u.rad).value)
     meanunit = np.mean(unit, axis=0)
     # defines tangent plane
@@ -2033,7 +2033,7 @@ def summarize_tracklet(arc):
     rasig = np.sqrt(np.diag(racovar))
     decp, deccovar = np.polyfit(dt, dectp, 1, w=1./dpos, cov='unscaled')
     decsig = np.sqrt(np.diag(deccovar))
-    meanra, meandec = ssapy.utils.unit2lb(meanunit[None, :])
+    meanra, meandec = ssapy.utils.unit_to_lb(meanunit[None, :])
     rap[1] += meanra[0]
     decp[1] += meandec[0]
     out = [(rap[1]*u.rad, decp[1]*u.rad),

--- a/ssapy/ellipsoid.py
+++ b/ssapy/ellipsoid.py
@@ -1,3 +1,11 @@
+"""
+Class to handle transformations between ECEF x,y,z coords and geodetic
+longitude, latitude, and height.
+
+Technically, only handles a one-axis ellipsoid, defined via a flattening
+parameter f, but that's good enough for simple Earth models.
+"""
+
 import numpy as np
 
 from ._ssapy import Ellipsoid

--- a/ssapy/gravity.py
+++ b/ssapy/gravity.py
@@ -1,8 +1,12 @@
+"""
+Classes for gravity-related accelerations.
+"""
+
 # from functools import lru_cache
 
 import numpy as np
 
-from .accel import Accel, _invnorm
+from .accel import Accel as _Accel, _invnorm
 from .utils import find_file, norm
 from . import _ssapy
 
@@ -220,7 +224,7 @@ class HarmonicCoefficients:
         )
 
 
-class AccelThirdBody(Accel):
+class AccelThirdBody(_Accel):
     """Acceleration due to a third body.
 
     Parameters
@@ -254,7 +258,7 @@ class AccelThirdBody(Accel):
         return -self.body.mu * (s / norm(s)**3 - d / norm(d)**3)
 
 
-class AccelHarmonic(Accel):
+class AccelHarmonic(_Accel):
     """Acceleration due to a harmonic potential.
 
     Parameters

--- a/ssapy/io.py
+++ b/ssapy/io.py
@@ -1,3 +1,7 @@
+"""
+Collection of functions to read from and write to various file formats.
+"""
+
 import datetime
 import numpy as np
 from astropy.time import Time

--- a/ssapy/orbit_solver.py
+++ b/ssapy/orbit_solver.py
@@ -1,5 +1,5 @@
 """
-Classes to solve for Keplerina orbital parameters from different initial inputs
+Classes to solve for Keplerian orbital parameters from different initial inputs
 
 # TODO: Provide overview of different solvers
 

--- a/ssapy/particles.py
+++ b/ssapy/particles.py
@@ -1,5 +1,9 @@
+"""
+Classes for sampling orbit model parameters.
+"""
+
 import numpy as np
-from .orbit import Orbit
+from .orbit import Orbit as _Orbit
 from .compute import rv
 from . import utils
 
@@ -113,7 +117,7 @@ class Particles:
         """ Get a list of orbits corresponding to each stored particle
         """
         if self._orbits is None:
-            self._orbits = [Orbit(p[0:3], p[3:6], t=self.epoch) for p in self.particles]
+            self._orbits = [_Orbit(p[0:3], p[3:6], t=self.epoch) for p in self.particles]
         return self._orbits
 
     @property
@@ -260,7 +264,7 @@ class Particles:
         prob = utils.get_normed_weights(self.ln_wts)
         particle_ndx = np.random.choice(self.num_particles, size=1, p=prob)
         p = self.particles[particle_ndx, :][0]
-        return [Orbit(p[0:3], p[3:6], t=self.epoch)]
+        return [_Orbit(p[0:3], p[3:6], t=self.epoch)]
 
     def mean(self):
         """ Evaluate the weighted mean of all particles

--- a/ssapy/plotUtils.py
+++ b/ssapy/plotUtils.py
@@ -1,3 +1,8 @@
+"""
+Utility functions for plotting.
+"""
+
+
 from .body import get_body
 from .compute import groundTrack
 from .constants import RGEO, EARTH_RADIUS

--- a/ssapy/propagator.py
+++ b/ssapy/propagator.py
@@ -1,3 +1,7 @@
+"""
+Classes for propagating orbits.
+"""
+
 from abc import ABC, abstractmethod
 import numpy as np
 from astropy.time import Time

--- a/ssapy/rvsampler.py
+++ b/ssapy/rvsampler.py
@@ -592,7 +592,7 @@ def circular_guess(arc, indices=[0, 1]):
     rRange = sol[0]
     vlos = sgn*np.sqrt(vr2(rRange))
     import ssapy.utils
-    ra, dec = ssapy.utils.unit2lb(np.array([lineOfSight]))
+    ra, dec = ssapy.utils.unit_to_lb(np.array([lineOfSight]))
     rGuess, vGuess = radecRateObsToRV(
         ra[0], dec[0], rRange, muAlpha, muDelta, vlos, rStation, vGroundSky)
     # ignores light-time correction, etc.

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -34,7 +34,7 @@ def test_vallado():
     ddpsi = -0.052195/206265 # arcsec->radians
     ddeps = -0.003875/206265 # arcsec->radians
 
-    rot = ssapy.utils.teme2gcrf(t)
+    rot = ssapy.utils.teme_to_gcrf(t)
 
     # 10 cm precision
     np.testing.assert_allclose(np.dot(rot, rteme), rgcrf, rtol=0, atol=1e-4)
@@ -45,7 +45,7 @@ def test_vallado():
     np.testing.assert_allclose(np.dot(rot.T, rgcrf), rteme, rtol=0, atol=1e-4)
     np.testing.assert_allclose(np.dot(rot.T, vgcrf), vteme, rtol=0, atol=1e-7)
 
-    rotT = ssapy.utils.gcrf2teme(t)
+    rotT = ssapy.utils.gcrf_to_teme(t)
     np.testing.assert_allclose(np.dot(rotT, rgcrf), rteme, rtol=0, atol=1e-4)
     np.testing.assert_allclose(np.dot(rotT, vgcrf), vteme, rtol=0, atol=1e-7)
 
@@ -73,7 +73,7 @@ def test_teme_orekit():
     for _ in range(100):
         rteme = np.random.uniform(low=-1000, high=1000, size=(10, 3))
         t = Time(np.random.uniform(low=0, high=1e8), format='gps')
-        rot = ssapy.utils.teme2gcrf(t)
+        rot = ssapy.utils.teme_to_gcrf(t)
         rgcrf = np.dot(rot, rteme.T).T
 
         oreDate = AbsoluteDate(t.isot, TimeScalesFactory.getUTC())

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -14,7 +14,7 @@ from ssapy.orbit import _ellipticalEccentricToTrueLongitude, _ellipticalTrueToEc
 from ssapy.orbit import _hyperbolicEccentricToTrueLongitude, _hyperbolicTrueToEccentricLongitude
 from ssapy.orbit import _ellipticalEccentricToMeanLongitude, _ellipticalMeanToEccentricLongitude
 from ssapy.orbit import _hyperbolicEccentricToMeanLongitude, _hyperbolicMeanToEccentricLongitude
-from ssapy.utils import normed, norm, teme2gcrf
+from ssapy.utils import normed, norm, teme_to_gcrf
 from ssapy_test_helpers import timer, checkAngle, checkSphere
 
 
@@ -1682,7 +1682,7 @@ def test_sgp4():
             times.append(Time(timestr))
         times = Time(times)
 
-        rot = teme2gcrf(times[0])
+        rot = teme_to_gcrf(times[0])
         x = np.cos(np.deg2rad(b3['azimuthAngle'])) * np.cos(np.deg2rad(b3['polarAngle']))
         y = np.sin(np.deg2rad(b3['azimuthAngle'])) * np.cos(np.deg2rad(b3['polarAngle']))
         z = np.sin(np.deg2rad(b3['polarAngle']))
@@ -1699,7 +1699,7 @@ def test_sgp4():
             vsgp4.append(v)
         rsgp4 = np.array(rsgp4)*1e3
         vsgp4 = np.array(vsgp4)*1e3
-        rot = teme2gcrf(orbit.t)
+        rot = teme_to_gcrf(orbit.t)
         rsgp4 = np.dot(rot, rsgp4.T).T
         vsgp4 = np.dot(rot, vsgp4.T).T
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,27 +82,27 @@ def test_angular_conversions():
     np.random.seed(seed)
     npts = 10000
     uv = normed(np.random.randn(npts, 3))
-    lb = utils.unit2lb(uv)
-    tp = utils.unit2tp(uv)
+    lb = utils.unit_to_lb(uv)
+    tp = utils.unit_to_tp(uv)
     # round trips
     # 3 systems, back and forth to all other systems -> 6 tests.
     np.testing.assert_allclose(uv,
-                               utils.lb2unit(*utils.unit2lb(uv)),
+                               utils.lb_to_unit(*utils.unit_to_lb(uv)),
                                rtol=0, atol=1e-10)
     np.testing.assert_allclose(uv,
-                               utils.tp2unit(*utils.unit2tp(uv)),
+                               utils.tp_to_unit(*utils.unit_to_tp(uv)),
                                rtol=0, atol=1e-10)
     np.testing.assert_allclose(np.concatenate(tp),
-                               np.concatenate(utils.unit2tp(utils.tp2unit(*tp))),
+                               np.concatenate(utils.unit_to_tp(utils.tp_to_unit(*tp))),
                                rtol=0, atol=1e-10)
     np.testing.assert_allclose(np.concatenate(tp),
-                               np.concatenate(utils.lb2tp(*utils.tp2lb(*tp))),
+                               np.concatenate(utils.lb_to_tp(*utils.tp_to_lb(*tp))),
                                rtol=0, atol=1e-10)
     np.testing.assert_allclose(np.concatenate(lb),
-                               np.concatenate(utils.unit2lb(utils.lb2unit(*lb))),
+                               np.concatenate(utils.unit_to_lb(utils.lb_to_unit(*lb))),
                                rtol=0, atol=1e-10)
     np.testing.assert_allclose(np.concatenate(lb),
-                               np.concatenate(utils.tp2lb(*utils.lb2tp(*lb))),
+                               np.concatenate(utils.tp_to_lb(*utils.lb_to_tp(*lb))),
                                rtol=0, atol=1e-10)
 
     # check tangent plane round tripping.
@@ -111,33 +111,33 @@ def test_angular_conversions():
     # so we need to make up some lcen, bcen to project from.
     noise = np.random.randn(npts, 3)*0.01
     uv2 = normed(uv + noise)
-    lcen, bcen = utils.unit2lb(uv2)
-    xy = utils.lb2tan(*lb, lcen=lcen, bcen=bcen)
+    lcen, bcen = utils.unit_to_lb(uv2)
+    xy = utils.lb_to_tan(*lb, lcen=lcen, bcen=bcen)
 
     # vector lcen, bcen
     np.testing.assert_allclose(
         np.concatenate(lb),
-        np.concatenate(utils.tan2lb(*utils.lb2tan(*lb, lcen=lcen, bcen=bcen),
+        np.concatenate(utils.tan_to_lb(*utils.lb_to_tan(*lb, lcen=lcen, bcen=bcen),
                                      lcen=lcen, bcen=bcen)))
     np.testing.assert_allclose(
         np.concatenate(xy),
-        np.concatenate(utils.lb2tan(*utils.tan2lb(*xy, lcen=lcen, bcen=bcen),
+        np.concatenate(utils.lb_to_tan(*utils.tan_to_lb(*xy, lcen=lcen, bcen=bcen),
                                      lcen=lcen, bcen=bcen)))
 
     # single lcen, bcen; careful to choose all points to be on same hemisphere
     uv2 = uv.copy()
     uv2[:, 0] = np.abs(uv2[:, 0])
     lcen, bcen = (0, 0)
-    lb2 = utils.unit2lb(uv2)
-    xy2 = utils.lb2tan(*lb2, lcen=lcen, bcen=bcen)
+    lb2 = utils.unit_to_lb(uv2)
+    xy2 = utils.lb_to_tan(*lb2, lcen=lcen, bcen=bcen)
 
     np.testing.assert_allclose(
         np.concatenate(lb2),
-        np.concatenate(utils.tan2lb(*utils.lb2tan(*lb2, lcen=lcen, bcen=bcen),
+        np.concatenate(utils.tan_to_lb(*utils.lb_to_tan(*lb2, lcen=lcen, bcen=bcen),
                                      lcen=lcen, bcen=bcen)))
     np.testing.assert_allclose(
         np.concatenate(xy2),
-        np.concatenate(utils.lb2tan(*utils.tan2lb(*xy2, lcen=lcen, bcen=bcen),
+        np.concatenate(utils.lb_to_tan(*utils.tan_to_lb(*xy2, lcen=lcen, bcen=bcen),
                                      lcen=lcen, bcen=bcen)))
 
 


### PR DESCRIPTION
Add some basic documentation for the API reference. Also clean up some of the imports so that the imported classes don't appear as duplicates in the API reference. I wonder if there is a cleaner way to do that than importing `Thing as _Thing` like I did.

Add a README in `docs/` to explain how to build the docs.

Also fix some leftover `x2y` -> `x_to_y` references to util functions, mostly in tests.