### PR TITLE
Fix docutils/sphinx-rtd-theme dependency issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docutils
+docutils<0.21
 sphinx
 sphinx-rtd-theme
 sphinx-copybutton

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         'ipyvolume',
         'ipython_genutils',
         'jplephem',
-        'docutils',
+        'docutils<0.21',
         'sphinx',
         'sphinx-rtd-theme',
         'sphinx-copybutton',

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         'ipython_genutils',
         'jplephem',
         'docutils<0.21',
+        'pytest',
         'sphinx',
         'sphinx-rtd-theme',
         'sphinx-copybutton',


### PR DESCRIPTION
Fix a dependency issue where sphinx-rtd-theme requires docutils<0.21 [[1]](https://github.com/readthedocs/sphinx_rtd_theme/issues/1557), but it wasn't being obeyed by pip automatically. So now we pin the docutils version to be less than 0.21.