### PR TITLE
Modify checkAngle function to allow non-default rtol

### DIFF
--- a/tests/ssapy_test_helpers.py
+++ b/tests/ssapy_test_helpers.py
@@ -19,7 +19,7 @@ def timer(f):
 def checkAngle(a, b, rtol=0, atol=1e-14):
     diff = (a-b)%(2*np.pi)
     absdiff = np.min([np.abs(diff), np.abs(2*np.pi-diff)], axis=0)
-    np.testing.assert_allclose(absdiff, 0, rtol=0, atol=atol)
+    np.testing.assert_allclose(absdiff, 0, rtol=rtol, atol=atol)
 
 
 def checkSphere(lon1, lat1, lon2, lat2, atol=1e-14, verbose=False):


### PR DESCRIPTION
The checkAngle function currently uses a fixed relative tolerance (rtol) of 0, even if a user specifies a different rtol value as an argument to the function.  This pull request replaces the fixed, default value of rtol with the user-supplied value.