### PR TITLE
Add meaning of SOFA acronym to function comments

### DIFF
--- a/ssapy/utils.py
+++ b/ssapy/utils.py
@@ -564,6 +564,7 @@ def catalog_to_apparent(
     # Code below modeled after SOFA iauPmpx, iauAb routines, but a bit simpler
     # since SSA requirements are only ~arcsec or so.
     # aulty = (u.au / (299792458 * u.m / u.s)).to(u.year).value
+    # SOFA is the Standards of Fundamental Astronomy.
     obsPos, obsVel = get_body_barycentric_posvel('earth', tTime)
     pob = obsPos.xyz.to(u.AU).value
     vob = obsVel.xyz.to(u.m / u.s).value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,7 +30,9 @@ def test_catalog_to_apparent():
 
 @timer
 def test_catalog_to_apparent_SOFA():
-    """Checking against test case using SOFA library"""
+    """Checking against test case using SOFA library,
+    where SOFA is the Standards of Fundamental Astronomy.
+    """
     t = Time("2013-04-02T23:15:43.55", scale='utc')
     ra = np.array([np.deg2rad(15*(14+34/60+16.81183/3600))])
     dec = np.array([-np.deg2rad(12+31/60+10.3965/3600)])


### PR DESCRIPTION
The acronym SOFA appears in SSAPy but is not explained.  This pull request adds comments to explain that SOFA is the Standards of Fundamental Astronomy.