### PR TITLE
Fix issue with building image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Build & Deploy centos-s8
         uses: docker/build-push-action@v5
         with:
-          context: .docker/Dockerfile
+          context: ${{ github.workspace }}/.docker/Dockerfile
           platforms: 'linux/amd64,linux/arm64'
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}


### PR DESCRIPTION
Add code base directory to context path. This, hopefully, fixes and issue where the Dockerfile can't be found by the `docker/build-push-action@v5` action.