### PR TITLE
Split maneuver test into three separate tests

### DIFF
--- a/tests/test_accel.py
+++ b/tests/test_accel.py
@@ -1068,8 +1068,9 @@ def test_reverse():
 @timer
 def test_Hohmann_transfer():
     """
-    Test Hohmann transfer between Low Earth Orbit (LEO) and Geostationary Orbit (GEO).
-    Check that (a, e, i) are close to expectations.
+    Test Hohmann transfer between Low Earth Orbit (LEO) and Geostationary 
+    Orbit (GEO).  Check that the semi-major axis (a), eccentricity (e), and
+    inclination (i) are close to expectations.
     """
     earthrad = ssapy.constants.WGS84_EARTH_RADIUS
     rleo = earthrad + 300*1000
@@ -1101,8 +1102,8 @@ def test_Hohmann_transfer():
 
 def test_inclination_change():
     """
-    Test inclination change with a small delta-v.  Check that (a, e, i)
-    are close to expectations.
+    Test inclination change with a small delta-v.  Check that the semi-major
+    axis (a), eccentricity (e), and inclination (i) are close to expectations.
     """
     rgeo = ssapy.constants.RGEO
     mu = ssapy.constants.WGS84_EARTH_MU
@@ -1126,8 +1127,8 @@ def test_inclination_change():
 
 def test_bielliptic_transfer():
     """
-    Test bielliptic transfer between two orbits.  Check that
-    (a, e, i) are close to expectations.
+    Test bielliptic transfer between two orbits.  Check that the semi-major
+    axis (a), eccentricity (e), and inclination (i) are close to expectations.
     """
     mu = ssapy.constants.WGS84_EARTH_MU
     t0 = Time('2020-01-01T00:00:00').gps

--- a/tests/test_accel.py
+++ b/tests/test_accel.py
@@ -1107,12 +1107,13 @@ def test_inclination_change():
     rgeo = ssapy.constants.RGEO
     mu = ssapy.constants.WGS84_EARTH_MU
     t0 = Time('2020-01-01T00:00:00').gps
-    T2 = 2*np.pi*np.sqrt(rgeo**3/mu)
+    T1 = 2*np.pi*np.sqrt(rgeo**3/mu)
     di = 0.01  # change inclination by 0.01 rad
-    dvi = di*2*np.pi/T2*rgeo  # approximate delta-v needed for plane change
+    n = 2 * np.pi / T1  # mean motion
+    dvi = di * n * rgeo  # approximate delta-v needed for plane change
     burni = ssapy.AccelConstNTW(
         [0, 0, dvi],
-        time_breakpoints=[t0+T2-0.5, t0+T2+0.5]
+        time_breakpoints=[t0+T1-0.5, t0+T1+0.5]
     )
     acceli = ssapy.AccelSum([ssapy.AccelKepler(mu), burni])
     propi = ssapy.propagator.default_numerical(accel=acceli)


### PR DESCRIPTION
The original test called test_maneuvers() contained three separate maneuvers.  This pull request separates the three maneuvers into three separate tests.  These changes make it clearer what variables are needed for the different maneuvers and allows greater test resolution. Minor documentation changes are also made to improve spelling or clarity.