### PR TITLE
Add test of Keplerian element evaluation from position and velocity

### DIFF
--- a/tests/test_accel.py
+++ b/tests/test_accel.py
@@ -1067,10 +1067,13 @@ def test_reverse():
 
 
 @timer
-def test_Hohmann_transfer():
-    """
-    Perform a Hohmann transfer from Low Earth Orbit (LEO) to Geostationary Orbit (GEO).
-    """
+def test_maneuvers():
+    # three maneuvers, Hohman transfer, inclination change, bielliptic transfer
+    # hohman transfer from LEO to GEO; test that eccentricity and
+    # final semimajor axis are close to expectations.
+    # inclination change: do tiny burn to change inclination.  Make
+    # sure that di ~ dv * n * a, and that a and e don't change much.
+    # first a Hohman transfer
     earthrad = ssapy.constants.WGS84_EARTH_RADIUS
     rleo = earthrad + 300*1000
     rgeo = ssapy.constants.RGEO
@@ -1100,19 +1103,10 @@ def test_Hohmann_transfer():
     np.testing.assert_allclose(orbfinal.e, 0, atol=1e-5)
     np.testing.assert_allclose(orbfinal.i, 0, atol=1e-5)
     np.testing.assert_allclose(orbfinal.a, ssapy.constants.RGEO, atol=10)
-
-@timer
-def test_inclination_change():
-    """
-    Perform a small inclination change for a geostationary orbit.
-    """
-    rgeo = ssapy.constants.RGEO
-    mu = ssapy.constants.WGS84_EARTH_MU
-    t0 = Time('2020-01-01T00:00:00').gps
-    T1 = 2*np.pi*np.sqrt(rgeo**3/mu)
-    di = 0.01  # change inclination by 0.01 rad
-    n = 2 * np.pi / T1  # mean motion
-    dvi = di * n * rgeo  # approximate delta-v needed for inclination change
+    # Next, an inclination change.
+    # change inclination by 0.01 rad
+    di = 0.01
+    dvi = di*2*np.pi/T2*rgeo
     burni = ssapy.AccelConstNTW(
         [0, 0, dvi],
         time_breakpoints=[t0+T1-0.5, t0+T1+0.5]
@@ -1127,14 +1121,7 @@ def test_inclination_change():
     np.testing.assert_allclose(orbfinal.a, ssapy.constants.RGEO, atol=1)
     np.testing.assert_allclose(orbfinal.e, 0, atol=1e-6)
     np.testing.assert_allclose(orbfinal.i, di, atol=1e-6)
-
-@timer
-def test_bielliptic_transfer():
-    """
-    Test of bi-elliptic transfer from an initial orbit to a final orbit.
-    """
-    mu = ssapy.constants.WGS84_EARTH_MU
-    t0 = Time('2020-01-01T00:00:00').gps
+    # Finally, a bielliptic transfer
     a1 = 7000000
     a4 = 105000000
     rb = 210000000

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1900,6 +1900,57 @@ def test_musun():
     np.testing.assert_allclose(orbit.v, v)
 
 
+def test_MG_2_3():
+    """Exercise 2.3 from Montenbruck and Gill
+    Tests conversion of position and velocity vectors to Keplerian elements
+    """
+    # Provided position and velocity vectors
+    r_ref = np.array([10000.0, 40000.0, -5000.0]) * 1000  # [m]
+    v_ref = np.array([-1.5, 1.0, -0.1]) * 1000  # [m/s]
+
+    # Instantiate Orbit object with position and velocity
+    t = Time("2020-01-01 00:00:00.000000")
+    orbit = ssapy.Orbit(r_ref, v_ref, t=t)
+
+    # Compute Keplerian elements for this orbit
+    orbit._setKeplerian()
+
+    # Reference element values provided in Montenbruck and Gill
+    a_ref = 25015.181 * 1000  # semi-major axis [m]
+    e_ref = 0.7079772  # eccentricity
+    i_ref = np.deg2rad(6.971)  # inclination
+    raan_ref = np.deg2rad(173.290)  # right ascension of ascending node
+    pa_ref = np.deg2rad(91.553)  # argument of perigee
+    meanAnomaly_ref = np.deg2rad(144.225)  # mean anomaly
+
+    # Check that reference elements and computed elements are close
+    np.testing.assert_allclose(
+        a_ref, orbit.a, atol=1e-5, err_msg="Semi-major axis test failed"
+    )
+    np.testing.assert_allclose(
+        e_ref, orbit.e, atol=1e-5, err_msg="Eccentricity test failed"
+    )
+    np.testing.assert_allclose(
+        i_ref, orbit.i, atol=1e-5, err_msg="Inclination test failed"
+    )
+    np.testing.assert_allclose(
+        raan_ref,
+        orbit.raan,
+        atol=1e-5,
+        err_msg="Right ascension of ascending node test failed",
+    )
+    np.testing.assert_allclose(
+        pa_ref, orbit.pa, atol=1e-5, err_msg="Argument of perigee test failed"
+    )
+    np.testing.assert_allclose(
+        meanAnomaly_ref,
+        orbit.meanAnomaly,
+        atol=1e-5,
+        err_msg="Mean anomaly test failed",
+    )
+
+
+
 if __name__ == '__main__':
     from argparse import ArgumentParser
     parser = ArgumentParser()
@@ -1935,6 +1986,7 @@ if __name__ == '__main__':
     # test_light_time_correction()
     test_find_passes()
     # test_musun()
+    # test_MG_2_3()
 
     if args.prof:
         import pstats


### PR DESCRIPTION
This pull request adds exercise 3.2 from Montenbruck and Gill to the test suite for the `orbit` module in SSAPy.  The test checks that the Keplerian elements computed with SSAPy for a particular position and velocity vector are as expected to within a specified absolute error tolerance.