### PR TITLE
Fix test of sun's gravitational parameter

### DIFF
--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1886,7 +1886,7 @@ def test_musun():
     # failing example.
 
     a = u.AU.to(u.m)
-    mu = ssapy.constants.GM_SUN
+    mu = ssapy.constants.SUN_MU
     e = 0.001
     i = 0.001
     pa = 0.001


### PR DESCRIPTION
The `test_musun()` test in tests/test_orbit.py currently fails because the module `ssapy.constants` has no attribute `GM_SUN`. This pull request fixes the test so that it passes by replacing `ssapy.constants.GM_SUN` with `ssapy.constants.SUN_MU`.