### PR TITLE
Add docstring explaining origin and purpose of test

### DIFF
--- a/tests/test_accel.py
+++ b/tests/test_accel.py
@@ -564,6 +564,9 @@ def test_MG_3_4_scipy():
 
 @timer
 def test_MG_3_4_rk78():
+    """Exercise 3.4 from Montenbruck and Gill.  Tests SSAPy orbit propagation
+    with perturbations.
+    """
     t = Time("1999-03-01", scale='utc')
     # LEO sat
     kElements = [7178e3, 0.001, np.deg2rad(98.57), 0.0, 0.0, 0.0]


### PR DESCRIPTION
This pull request adds a docstring to a test in `test_accel.py`, explaining that the test is from exercise 3.4 in Montenbruck and Gill and that the test is meant to check orbit propagation when perturbations are taken into account.