### PR TITLE
Refactor tests to simplify sampling of LEO and GEO orbits

### DIFF
--- a/tests/ssapy_test_helpers.py
+++ b/tests/ssapy_test_helpers.py
@@ -1,4 +1,5 @@
 import numpy as np
+import ssapy
 
 
 def timer(f):
@@ -34,3 +35,45 @@ def checkSphere(lon1, lat1, lon2, lat2, atol=1e-14, verbose=False):
     if verbose:
         print(f"max angle difference {np.rad2deg(np.max(da))*3600} arcsec")
     np.testing.assert_allclose(da, 0, rtol=0, atol=atol)
+
+
+def sample_orbit(t, r_low, r_high, v_low, v_high):
+    """
+    Sample a random orbit by drawing a position vector with magnitude in
+    (r_low, r_high), a velocity vector with magnitude in (v_low, v_high), and
+    a direction, at time t.
+    """
+    def sample_vector(lower, upper):
+        """
+        Helper function for sampling a position and velocity vector.
+        """
+        # Sample magnitude of vector
+        mag = np.random.uniform(lower, upper)
+        # Sample a random direction (not uniform on sphere)
+        theta = np.random.uniform(0, 2*np.pi)
+        phi = np.random.uniform(0, np.pi)
+        vec_x = mag * np.cos(theta) * np.sin(phi)
+        vec_y = mag * np.sin(theta) * np.sin(phi)
+        vec_z = mag * np.cos(phi)
+        vec = np.array([vec_x, vec_y, vec_z])
+        return vec
+    
+    # Sample position and velocity
+    r = sample_vector(r_low, r_high)
+    v = sample_vector(v_low, v_high)
+
+    return ssapy.Orbit(r, v, t)
+
+
+def sample_GEO_orbit(t, r_low=4e7, r_high=5e7, v_low=2.7e3, v_high=3.3e3):
+    """
+    Returns a ssapy.Orbit object with a distance near RGEO and a velocity near VGEO.
+    """
+    return sample_orbit(t, r_low, r_high, v_low, v_high)
+
+
+def sample_LEO_orbit(t, r_low=7e6, r_high=1e7, v_low=7.7e3, v_high=7.9e3):
+    """
+    Returns a ssapy.Orbit object with a position near LEO and a velocity near VLEO.
+    """
+    return sample_orbit(t, r_low, r_high, v_low, v_high)

--- a/tests/test_accel.py
+++ b/tests/test_accel.py
@@ -4,7 +4,7 @@ import astropy.units as u
 
 import ssapy
 from ssapy.utils import norm, iers_interp
-from ssapy_test_helpers import timer
+from ssapy_test_helpers import timer, sample_LEO_orbit, sample_GEO_orbit
 
 iers_interp(0.0)  # Prime the IERS interpolant cache
 earth = ssapy.get_body("earth")
@@ -715,25 +715,7 @@ def test_RK4_vs_analytic():
 
     for _ in range(10):
         while True:
-            # Pick a distance near GEO
-            r = np.random.uniform(4e7, 5e7)
-            # Pick a random direction (not uniform on sphere)
-            theta = np.random.uniform(0, 2*np.pi)
-            phi = np.random.uniform(0, np.pi)
-            x = r * np.cos(theta) * np.sin(phi)
-            y = r * np.sin(theta) * np.sin(phi)
-            z = r * np.cos(phi)
-            r = np.array([x, y, z])
-            # Pick a velocity near VGEO
-            v = np.random.uniform(2.7e3, 3.3e3)
-            # and a randomish direction
-            theta = np.random.uniform(0, 2*np.pi)
-            phi = np.random.uniform(0, np.pi)
-            vx = v * np.cos(theta) * np.sin(phi)
-            vy = v * np.sin(theta) * np.sin(phi)
-            vz = v * np.cos(phi)
-            v = np.array([vx, vy, vz])
-            orbit = ssapy.Orbit(r, v, t0)
+            orbit = sample_GEO_orbit(t0)
             if norm(orbit.periapsis) > 1e7:
                 break
 
@@ -747,25 +729,7 @@ def test_RK4_vs_analytic():
     times = t0 + np.linspace(0, 5, 1000)*u.h
     for _ in range(10):
         while True:
-            # Repeat near LEO
-            r = np.random.uniform(7e6, 1e7)
-            # Pick a random direction (not uniform on sphere)
-            theta = np.random.uniform(0, 2*np.pi)
-            phi = np.random.uniform(0, np.pi)
-            x = r * np.cos(theta) * np.sin(phi)
-            y = r * np.sin(theta) * np.sin(phi)
-            z = r * np.cos(phi)
-            r = np.array([x, y, z])
-            # Pick a velocity near VLEO
-            v = np.random.uniform(7.7e3, 7.9e3)
-            # and a randomish direction
-            theta = np.random.uniform(0, 2*np.pi)
-            phi = np.random.uniform(0, np.pi)
-            vx = v * np.cos(theta) * np.sin(phi)
-            vy = v * np.sin(theta) * np.sin(phi)
-            vz = v * np.cos(phi)
-            v = np.array([vx, vy, vz])
-            orbit = ssapy.Orbit(r, v, t0.gps)
+            orbit = sample_LEO_orbit(t0)
             if norm(orbit.periapsis) > 6475e3:
                 break
 
@@ -787,25 +751,7 @@ def test_scipy_propagator():
 
     for _ in range(10):
         while True:
-            # Pick a distance near GEO
-            r = np.random.uniform(4e7, 5e7)
-            # Pick a random direction (not uniform on sphere)
-            theta = np.random.uniform(0, 2*np.pi)
-            phi = np.random.uniform(0, np.pi)
-            x = r * np.cos(theta) * np.sin(phi)
-            y = r * np.sin(theta) * np.sin(phi)
-            z = r * np.cos(phi)
-            r = np.array([x, y, z])
-            # Pick a velocity near VGEO
-            v = np.random.uniform(2.7e3, 3.3e3)
-            # and a randomish direction
-            theta = np.random.uniform(0, 2*np.pi)
-            phi = np.random.uniform(0, np.pi)
-            vx = v * np.cos(theta) * np.sin(phi)
-            vy = v * np.sin(theta) * np.sin(phi)
-            vz = v * np.cos(phi)
-            v = np.array([vx, vy, vz])
-            orbit = ssapy.Orbit(r, v, t0)
+            orbit = sample_GEO_orbit(t0)
             if norm(orbit.periapsis) > 1e7:
                 break
 
@@ -819,25 +765,7 @@ def test_scipy_propagator():
     times = t0 + np.linspace(0, 5, 1000)*u.h
     for _ in range(10):
         while True:
-            # Repeat near LEO
-            r = np.random.uniform(7e6, 1e7)
-            # Pick a random direction (not uniform on sphere)
-            theta = np.random.uniform(0, 2*np.pi)
-            phi = np.random.uniform(0, np.pi)
-            x = r * np.cos(theta) * np.sin(phi)
-            y = r * np.sin(theta) * np.sin(phi)
-            z = r * np.cos(phi)
-            r = np.array([x, y, z])
-            # Pick a velocity near VLEO
-            v = np.random.uniform(7.7e3, 7.9e3)
-            # and a randomish direction
-            theta = np.random.uniform(0, 2*np.pi)
-            phi = np.random.uniform(0, np.pi)
-            vx = v * np.cos(theta) * np.sin(phi)
-            vy = v * np.sin(theta) * np.sin(phi)
-            vz = v * np.cos(phi)
-            v = np.array([vx, vy, vz])
-            orbit = ssapy.Orbit(r, v, t0.gps)
+            orbit = sample_LEO_orbit(t0)
             if norm(orbit.periapsis) > 6475e3:
                 break
 
@@ -860,25 +788,7 @@ def test_RK8():
 
     for _ in range(10):
         while True:
-            # Pick a distance near GEO
-            r = np.random.uniform(4e7, 5e7)
-            # Pick a random direction (not uniform on sphere)
-            theta = np.random.uniform(0, 2*np.pi)
-            phi = np.random.uniform(0, np.pi)
-            x = r * np.cos(theta) * np.sin(phi)
-            y = r * np.sin(theta) * np.sin(phi)
-            z = r * np.cos(phi)
-            r = np.array([x, y, z])
-            # Pick a velocity near VGEO
-            v = np.random.uniform(2.7e3, 3.3e3)
-            # and a randomish direction
-            theta = np.random.uniform(0, 2*np.pi)
-            phi = np.random.uniform(0, np.pi)
-            vx = v * np.cos(theta) * np.sin(phi)
-            vy = v * np.sin(theta) * np.sin(phi)
-            vz = v * np.cos(phi)
-            v = np.array([vx, vy, vz])
-            orbit = ssapy.Orbit(r, v, t0)
+            orbit = sample_GEO_orbit(t0)
             if norm(orbit.periapsis) > 1e7:
                 break
 
@@ -895,25 +805,7 @@ def test_RK8():
     times = t0 + np.arange(0, 500)*30*u.s
     for _ in range(10):
         while True:
-            # Repeat near LEO
-            r = np.random.uniform(7e6, 1e7)
-            # Pick a random direction (not uniform on sphere)
-            theta = np.random.uniform(0, 2*np.pi)
-            phi = np.random.uniform(0, np.pi)
-            x = r * np.cos(theta) * np.sin(phi)
-            y = r * np.sin(theta) * np.sin(phi)
-            z = r * np.cos(phi)
-            r = np.array([x, y, z])
-            # Pick a velocity near VLEO
-            v = np.random.uniform(7.7e3, 7.9e3)
-            # and a randomish direction
-            theta = np.random.uniform(0, 2*np.pi)
-            phi = np.random.uniform(0, np.pi)
-            vx = v * np.cos(theta) * np.sin(phi)
-            vy = v * np.sin(theta) * np.sin(phi)
-            vz = v * np.cos(phi)
-            v = np.array([vx, vy, vz])
-            orbit = ssapy.Orbit(r, v, t0.gps)
+            orbit = sample_LEO_orbit(t0)
             if norm(orbit.periapsis) > 6475e3:
                 break
 
@@ -939,25 +831,7 @@ def test_RK78():
 
     for _ in range(10):
         while True:
-            # Pick a distance near GEO
-            r = np.random.uniform(4e7, 5e7)
-            # Pick a random direction (not uniform on sphere)
-            theta = np.random.uniform(0, 2*np.pi)
-            phi = np.random.uniform(0, np.pi)
-            x = r * np.cos(theta) * np.sin(phi)
-            y = r * np.sin(theta) * np.sin(phi)
-            z = r * np.cos(phi)
-            r = np.array([x, y, z])
-            # Pick a velocity near VGEO
-            v = np.random.uniform(2.7e3, 3.3e3)
-            # and a randomish direction
-            theta = np.random.uniform(0, 2*np.pi)
-            phi = np.random.uniform(0, np.pi)
-            vx = v * np.cos(theta) * np.sin(phi)
-            vy = v * np.sin(theta) * np.sin(phi)
-            vz = v * np.cos(phi)
-            v = np.array([vx, vy, vz])
-            orbit = ssapy.Orbit(r, v, t0)
+            orbit = sample_GEO_orbit(t0)
             if norm(orbit.periapsis) > 1e7:
                 break
 
@@ -975,25 +849,7 @@ def test_RK78():
     times = t0 + np.arange(0, 500)*30*u.s
     for _ in range(10):
         while True:
-            # Repeat near LEO
-            r = np.random.uniform(7e6, 1e7)
-            # Pick a random direction (not uniform on sphere)
-            theta = np.random.uniform(0, 2*np.pi)
-            phi = np.random.uniform(0, np.pi)
-            x = r * np.cos(theta) * np.sin(phi)
-            y = r * np.sin(theta) * np.sin(phi)
-            z = r * np.cos(phi)
-            r = np.array([x, y, z])
-            # Pick a velocity near VLEO
-            v = np.random.uniform(7.7e3, 7.9e3)
-            # and a randomish direction
-            theta = np.random.uniform(0, 2*np.pi)
-            phi = np.random.uniform(0, np.pi)
-            vx = v * np.cos(theta) * np.sin(phi)
-            vy = v * np.sin(theta) * np.sin(phi)
-            vz = v * np.cos(phi)
-            v = np.array([vx, vy, vz])
-            orbit = ssapy.Orbit(r, v, t0.gps)
+            orbit = sample_LEO_orbit(t0)
             if norm(orbit.periapsis) > 6475e3:
                 break
 


### PR DESCRIPTION
Several tests in `tests/test_accel.py` and `tests/test_orbit.py` rely on randomly sampling LEO or GEO orbits.  Each time the sampling is done, the same lines of code are repeated.  This pull request extracts the orbit sampling code into functions in `tests/ssapy_test_helpers.py` so that less code is repeated in the tests.