### PR TITLE
Fix NumPy 2.x / Python 3.12 incompatibilities and B3 parser bugs from Claude

### DIFF
--- a/ssapy/correlate_tracks.py
+++ b/ssapy/correlate_tracks.py
@@ -701,7 +701,7 @@ def radeczn(orbit, arc, **kw):
         try:
             _ = len(arc['satID'])
             scalararc = False
-        except:
+        except TypeError:
             scalararc = True
         meanMotion = orbit.meanMotion
         tt = arc['time'].gps
@@ -1044,7 +1044,7 @@ class TrackBase:
             covar = np.diag([np.inf, np.inf, np.inf, np.inf])
         try:
             cinv = np.linalg.inv(covar)
-        except:
+        except np.linalg.LinAlgError:
             cinv = 1e-30
         measvec = np.array([arc0['ra'].to(u.rad).value,
                             arc0['dec'].to(u.rad).value,

--- a/ssapy/correlate_tracks.py
+++ b/ssapy/correlate_tracks.py
@@ -919,7 +919,7 @@ class TrackBase:
         else:
             # SVD seems more robust than direct np.linalg.det
             _, ss, _ = np.linalg.svd(2*np.pi*self.covar)
-            determinant = np.product(ss)
+            determinant = np.prod(ss)
             if determinant <= 0:
                 determinant = 1
                 if self.chi2 < 1e8:

--- a/ssapy/io.py
+++ b/ssapy/io.py
@@ -239,9 +239,9 @@ def make_tle(a, e, i, pa, raan, trueAnomaly, t):
 
     if not isinstance(t, Time):
         t = Time(t, format='gps')
-    year, day, hour, min, sec = t.utc.yday.split(':')
+    year, day, hour, minute, sec = t.utc.yday.split(':')
 
-    day = float(day) + (float(hour) + (float(min) + float(sec) / 60) / 60) / 24
+    day = float(day) + (float(hour) + (float(minute) + float(sec) / 60) / 60) / 24
 
     line1 += "{:02d}".format(int(year) % 100)
     line1 += "{:012.8f}".format(day)
@@ -263,7 +263,7 @@ def make_tle(a, e, i, pa, raan, trueAnomaly, t):
 
     line2 += "{:8.4f} ".format(np.rad2deg(i % np.pi))
     line2 += "{:8.4f} ".format(np.rad2deg(raan % (2 * np.pi)))
-    line2 += "{:07d} ".format(int(e * 1e7))
+    line2 += "{:07d} ".format(round(e * 1e7))
     line2 += "{:8.4f} ".format(np.rad2deg(pa % (2 * np.pi)))
     meanAnomaly = _ellipticalEccentricToMeanAnomaly(
         _ellipticalTrueToEccentricAnomaly(
@@ -392,7 +392,7 @@ def parseB3Line(line):
         try:
             x = float(line[46:55])
             y = float(line[55:64])
-            z = float(line[65:73])
+            z = float(line[64:73])
         except ValueError:
             x = y = z = np.nan
     else:
@@ -552,7 +552,10 @@ def b3obs2pos(b3line):
             y_sat = b3line[55:64]
             z_sat = b3line[64:73]
         # Column 74 is blank
-        equinox = int(b3line[75])
+        if obs_type in (5, 9):
+            equinox = int(b3line[75])
+        else:
+            equinox = -999
     else:
         raise ValueError("B3OBS format error")
 

--- a/ssapy/particles.py
+++ b/ssapy/particles.py
@@ -188,7 +188,7 @@ class Particles:
         ln_wts += self.ln_wts
 
         # Append particles and weights in anticipation of resampling / downsampling
-        self.particles = np.row_stack((self.particles, epoch_particles.move(self.epoch)))
+        self.particles = np.vstack((self.particles, epoch_particles.move(self.epoch)))
         self.ln_wts = np.append(ln_wts, epoch_ln_wts)
 
         if np.logaddexp.reduce(self.ln_wts) < -100.:

--- a/ssapy/rvsampler.py
+++ b/ssapy/rvsampler.py
@@ -7,7 +7,7 @@ from astropy.time import Time
 from .orbit import Orbit
 from .propagator import KeplerianPropagator
 from .compute import dircos, radec, radec, radecRateObsToRV, rvObsToRaDecRate
-from .utils import norm, normed, normSq, cluster_emcee_walkers, unitAngle3
+from .utils import norm, normed, normSq, cluster_emcee_walkers, unitAngle3, _emcee_version_before_3
 from .constants import RGEO, VGEO, WGS84_EARTH_MU
 
 
@@ -974,7 +974,7 @@ class RVProbability:
         v = p[3:6]
         try:
             orbit = Orbit(r, v, self.epoch)
-        except:
+        except Exception:
             return -np.inf, -np.inf
 
         chilike, chiprior = self.chi(orbit)
@@ -1040,8 +1040,7 @@ class EmceeSampler:
         # Don't need emcee right here, but better to catch version
         # incompatibility in ctor than down below.
         import emcee
-        from distutils.version import LooseVersion
-        if LooseVersion(emcee.__version__) < LooseVersion("3.0"):
+        if _emcee_version_before_3(emcee.__version__):
             raise ValueError("emcee version at least 3.0rc2 required")
 
         self.probfn = probfn
@@ -1068,8 +1067,7 @@ class EmceeSampler:
             The log prior values for each step.
         """
         import emcee
-        from distutils.version import LooseVersion
-        if LooseVersion(emcee.__version__) < LooseVersion("3.0"):
+        if _emcee_version_before_3(emcee.__version__):
             raise ValueError("emcee version at least 3.0rc2 required")
         # Type for emcee 'blobs' metadata
         dtype = [("lnprior", float)]

--- a/ssapy/utils.py
+++ b/ssapy/utils.py
@@ -3,6 +3,7 @@
 
 import sys
 import os
+import re
 import numpy as np
 from astropy.time import Time
 import astropy.units as u
@@ -10,6 +11,18 @@ from typing import Union, Tuple
 
 from . import datadir
 from .constants import RGEO, EARTH_RADIUS, MOON_RADIUS, WGS84_EARTH_OMEGA
+
+
+def _emcee_version_before_3(version_string):
+    """Return True if an emcee version string predates the 3.0 release.
+
+    Avoids ``distutils.version.LooseVersion``, which was removed from the
+    standard library in Python 3.12.
+    """
+    match = re.match(r"(\d+)", version_string)
+    if match is None:
+        return False
+    return int(match.group(1)) < 3
 
 try:
     import erfa
@@ -352,8 +365,7 @@ def cluster_emcee_walkers(
     The Astrophysical Journal, 745(2), 198.
     """
     import emcee
-    from distutils.version import LooseVersion
-    if LooseVersion(emcee.__version__) < LooseVersion("3.0"):
+    if _emcee_version_before_3(emcee.__version__):
         raise ValueError("emcee version at least 3.0rc2 required")
     if verbose:
         out = "Clustering emcee walkers with threshold multiplier {:3.2f}"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -47,3 +47,66 @@ def test_make_tle_and_parse_tle():
 def test_parse_overpunched():
     assert io.parse_overpunched("J1234") == "-11234"
     assert io.parse_overpunched("51234") == "51234"
+
+def test_parseB3Line_type9_sensor_position():
+    # Regression test: the z coordinate of the sensor position for
+    # space-based observation types (8 and 9) was previously read from
+    # columns [65:73] instead of [64:73], dropping a digit and
+    # misaligning the field.
+    from ssapy.io import parseB3Line
+
+    line = list(" " * 76)
+
+    def put(start, text):
+        line[start:start + len(text)] = list(text)
+
+    put(0, "U")          # security classification
+    put(1, "12345")      # satellite ID
+    put(6, "511")        # sensor ID
+    put(9, "21")         # year
+    put(11, "123")       # day of year
+    put(14, "12")        # hour
+    put(16, "34")        # minute
+    put(18, "56000")     # milliseconds of minute
+    put(23, " 451234")   # polar angle (declination)
+    put(30, "1230456")   # RA in hhmmsss (type 9)
+    put(46, "  1234567")  # sensor x, columns 47-55
+    put(55, " -2345678")  # sensor y, columns 56-64
+    put(64, "  3456789")  # sensor z, columns 65-73
+    put(74, "9")          # observation type
+    put(75, "1")          # equinox type
+
+    rec = parseB3Line("".join(line))
+    assert rec['x'][0] == 1234567.0
+    assert rec['y'][0] == -2345678.0
+    assert rec['z'][0] == 3456789.0
+    assert rec['type'][0] == 9
+    assert rec['equinoxType'][0] == 1
+
+
+def test_b3obs2pos_blank_equinox_column():
+    # Regression test: b3obs2pos previously did int(line[75])
+    # unconditionally, raising ValueError for the (common) observation
+    # types whose equinox column is blank.
+    from ssapy.io import b3obs2pos
+
+    line = list(" " * 76)
+
+    def put(start, text):
+        line[start:start + len(text)] = list(text)
+
+    put(0, "U")
+    put(1, "12345")
+    put(6, "511")
+    put(9, "21")
+    put(11, "123")
+    put(14, "12")
+    put(16, "34")
+    put(18, "56000")
+    put(23, " 451234")   # elevation
+    put(30, "1230456")   # azimuth
+    put(74, "1")         # obs type 1: azimuth & elevation, no equinox
+
+    pos = b3obs2pos("".join(line))
+    assert pos["satnum"] == 12345
+    assert pos["sensnum"] == 511


### PR DESCRIPTION
# Fix NumPy 2.x / Python 3.12 incompatibilities and B3 parser bugs

## Summary

This PR fixes one runtime crash on NumPy ≥ 2.0, an ImportError path on Python ≥ 3.12, two data-corruption/crash bugs in the B3 observation parser, and a few smaller robustness issues. All existing tests pass, and two regression tests are added for the B3 fixes.

## Changes

### NumPy 2.x compatibility
- `correlate_tracks.py`: `np.product` was removed in NumPy 2.0, so `TrackGauss.gaussian_approximation` raises `AttributeError` at runtime on modern NumPy (this code path is not exercised by CI, which is why tests never caught it). Replaced with `np.prod`.
- `particles.py`: `np.row_stack` is deprecated and slated for removal; replaced with `np.vstack`.

### Python 3.12 compatibility
- `rvsampler.py`, `utils.py`: `distutils.version.LooseVersion` is used in three places to check the emcee version. `distutils` was removed from the standard library in Python 3.12, so these imports fail unless setuptools shims them. Added a small self-contained helper (`_emcee_version_before_3`) in `utils.py` and used it at all three sites.

### B3 observation parser (`io.py`)
- **`parseB3Line` off-by-one slice**: for space-based observation types 8 and 9, the sensor z coordinate was read from `line[65:73]` instead of `line[64:73]` — an 8-character field where x and y are 9 — dropping the leading digit and misaligning the value. `b3obs2pos` in the same module already used the correct slice. Regression test added.
- **`b3obs2pos` unconditional equinox parse**: `int(b3line[75])` raised `ValueError` for the common observation types whose equinox column is blank. Now guarded the same way `parseB3Line` does. Regression test added.
- **`make_tle`**: round rather than truncate eccentricity to 1e-7 (truncation loses the last digit for ~half of inputs due to floating-point representation), and renamed a local variable that shadowed the builtin `min`.

### Robustness
- Narrowed three bare `except:` clauses (`correlate_tracks.py` ×2, `rvsampler.py`). Bare except catches `KeyboardInterrupt`/`SystemExit`, making long MHT/MCMC runs un-interruptible at those points. Each is now narrowed to what the block actually expects (`TypeError`, `np.linalg.LinAlgError`, `Exception`).

## Testing

- Full test suite run locally on Python 3.12 / NumPy 2.4.4: **126 passed, 5 skipped** (includes `test_tracks.py` and `test_sampler.py`, which exercise the modified modules).
- Two new regression tests in `tests/test_io.py`:
  - `test_parseB3Line_type9_sensor_position` — verifies x/y/z column alignment for a synthetic type-9 record.
  - `test_b3obs2pos_blank_equinox_column` — verifies type-1 records with a blank equinox column parse without error.

## Notes for reviewers

A few related observations were left out of this PR since they may be intentional and deserve maintainer judgment:
- `b3obs2pos` parses range rate and sensor x/y/z into local variables but never returns them.
- `make_tle` maps an inclination of exactly 180° to 0° via `i % np.pi`.
- `b3obs2pos` skips the range entirely when the exponent column is blank, while `parseB3Line` treats a blank exponent as 0 — the two parsers disagree.

Happy to address any of these here or in a follow-up.
