### PR TITLE
Feature/tle propagation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@ SSAPy - Space Situational Awareness for Python
 .. |codecov_badge| image:: https://codecov.io/gh/LLNL/SSAPy/branch/main/graph/badge.svg
    :target: https://codecov.io/gh/LLNL/SSAPy
 
-.. |joss_badge| image:: https://joss.theoj.org/papers/a629353cbdd8d64a861bb807e12c5d06/status.svg
-   :target: https://joss.theoj.org/papers/a629353cbdd8d64a861bb807e12c5d06
+.. |joss_badge| image:: https://joss.theoj.org/papers/10.21105/joss.08147/status.svg
+   :target: https://doi.org/10.21105/joss.08147
 
 .. |pypi_badge| image:: https://badge.fury.io/py/llnl-ssapy.svg
    :target: https://badge.fury.io/py/llnl-ssapy
@@ -59,6 +59,25 @@ SSAPy includes:
 - Support for multiple coordinate frames and coordinate transformations,
   including GCRF, IERS, GCRS Cartesian, TEME Cartesian, RA/Dec, NTW,
   zenith/azimuth, apparent positions, and orthogonal tangent plane coordinates
+
+SSAPy-Toolkit
+-------------
+
+SSAPy provides the core high-fidelity propagation and modeling engine. Many
+higher-level, analysis-ready capabilities built on top of it live in the
+companion project
+`SSAPy-Toolkit <https://github.com/LLNL/SSAPy-Toolkit>`_ (sometimes abbreviated
+*SSATK*), including:
+
+- Higher-level utilities and convenience workflows that wrap common SSAPy tasks
+- Plotting tools for orbit and analysis visualization
+- GCRF-to-ITRF and related coordinate-conversion helpers
+- Lambertian magnitude / brightness calculations
+- Additional related extensions
+
+If your work centers on plotting, dashboards, convenience utilities, or
+higher-level workflows, SSAPy-Toolkit is often the best place to start — and the
+natural home for contributions of that kind.
 
 Installation
 ------------
@@ -170,9 +189,32 @@ Many thanks go to SSAPy's other
 Citing SSAPy
 ------------
 
-On GitHub, you can copy a citation in APA or BibTeX format via the
-"Cite this repository" button. If you prefer MLA or Chicago style citations,
-see the comments in
+If you use SSAPy in your research, please cite the JOSS paper:
+
+- Meyers, J. E., Schneider, M. D., Ebert, J. T., Schlafly, E. F., Yeager, T.,
+  Perloff, A., Merl, D., Lifset, N., Bernstein, J., Dawson, W. A., Golovich, N.,
+  Higgins, D., McGill, P., Miller, C., & Pruett, K. (2025). *SSAPy - Space
+  Situational Awareness for Python.* Journal of Open Source Software, 10(111),
+  8147. `doi:10.21105/joss.08147 <https://doi.org/10.21105/joss.08147>`_
+
+BibTeX::
+
+    @article{Meyers2025,
+      doi       = {10.21105/joss.08147},
+      url       = {https://doi.org/10.21105/joss.08147},
+      year      = {2025},
+      publisher = {The Open Journal},
+      volume    = {10},
+      number    = {111},
+      pages     = {8147},
+      author    = {Meyers, Joshua E. and Schneider, Michael D. and Ebert, Julia T. and Schlafly, Edward F. and Yeager, Travis and Perloff, Alexx and Merl, Daniel and Lifset, Noah and Bernstein, Jason and Dawson, William A. and Golovich, Nathan and Higgins, Denvir and McGill, Peter and Miller, Caleb and Pruett, Kerianne},
+      title     = {SSAPy - Space Situational Awareness for Python},
+      journal   = {Journal of Open Source Software}
+    }
+
+To cite the software itself, you can also copy a citation in APA or BibTeX format
+via the "Cite this repository" button on GitHub. If you prefer MLA or Chicago
+style citations, see the comments in
 `CITATION.cff <https://github.com/LLNL/SSAPy/blob/main/CITATION.cff>`_.
 
 You may also cite the following publications (click

--- a/README.rst
+++ b/README.rst
@@ -218,7 +218,7 @@ style citations, see the comments in
 `CITATION.cff <https://github.com/LLNL/SSAPy/blob/main/CITATION.cff>`_.
 
 You may also cite the following publications (click
-`here <https://github.com/LLNL/SSAPy/blob/main/docs/source/citations.bib>`_
+`here <https://github.com/LLNL/SSAPy/blob/main/docs/source/refs.bib>`_
 for BibTeX entries):
 
 - Yeager, T., Pruett, K., & Schneider, M. (2022). *Unaided Dynamical Orbit Stability in the Cislunar Regime.* Poster presentation, Cislunar Security Conference, USA.

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1,10 +1,14 @@
-@inproceedings{ssapyprep,
+@article{ssapyprep,
     title = {{SSAPy} - Space Situational Awareness for Python},
-    author = {Meyers, Joshua E. and Schneider, Michael D. and Ebert, Julia T. and Schlafly, Edward F. and Yeager, Travis and Perloff, Alexx and Merl, Daniel and Lifset, Noah and Berstein, Jason and Dawson, William A. and Golovich, Nathan and Higgins, Denvir and McGill, Peter and Miller, Caleb and Pruett, Kerianne},
-    booktitle = {The Journal of Open Source Software},
+    author = {Meyers, Joshua E. and Schneider, Michael D. and Ebert, Julia T. and Schlafly, Edward F. and Yeager, Travis and Perloff, Alexx and Merl, Daniel and Lifset, Noah and Bernstein, Jason and Dawson, William A. and Golovich, Nathan and Higgins, Denvir and McGill, Peter and Miller, Caleb and Pruett, Kerianne},
+    journal = {Journal of Open Source Software},
     publisher = {The Open Journal},
-    note = {Submitted to},
-    year = {2024}
+    year = {2025},
+    volume = {10},
+    number = {111},
+    pages = {8147},
+    doi = {10.21105/joss.08147},
+    url = {https://doi.org/10.21105/joss.08147}
 }
 
 @INPROCEEDINGS{2023amos.conf..208Y,

--- a/examples/tle_drag_paths.py
+++ b/examples/tle_drag_paths.py
@@ -45,11 +45,10 @@ GEO = ("1 41866U 16071A   24015.50000000 -.00000267  00000-0  00000+0 0  9990",
 def _direct_sgp4_gcrf(tle, dt_minutes):
     sat = Satrec.twoline2rv(*tle)
     t0 = Time(sat.jdsatepoch, format="jd") + sat.jdsatepochF * u.d
-    rs = []
-    for dt in dt_minutes:
-        _, r, _ = sat.sgp4_tsince(dt)
-        rs.append(np.array(r) * 1e3)  # km -> m, TEME
-    return (teme_to_gcrf(t0.gps) @ np.array(rs).T).T
+    gps = t0.gps + np.asarray(dt_minutes, dtype=float) * 60.0
+    rs = np.array([np.array(sat.sgp4_tsince(dt)[1]) * 1e3 for dt in dt_minutes])
+    rot = teme_to_gcrf(gps)                      # per-output-time (vectorized)
+    return np.einsum("nij,nj->ni", rot, rs)
 
 
 def demo_path_a():

--- a/examples/tle_drag_paths.py
+++ b/examples/tle_drag_paths.py
@@ -97,6 +97,50 @@ def demo_path_b():
     print("outperform SGP4.")
 
 
+def demo_joint_fit():
+    print("\n" + "=" * 68)
+    print("PATH B (joint) -- estimate the epoch state AND drag together")
+    print("=" * 68)
+    from ssapy.tle_drag import (drag_propagator, propkw_from_cd_a_over_m,
+                                fit_drag, fit_orbit_drag)
+
+    # Self-consistent numerical truth: a known epoch state + known Cd*A/m,
+    # propagated by the numerical model (stands in for precise ephemeris).
+    prop = drag_propagator(harmonics=(4, 4))
+    o0 = Orbit.fromTLETuple(ISS)
+    t0 = o0.t
+    r_true, v_true = np.asarray(o0.r), np.asarray(o0.v)
+    cd_true = 5.0e-3
+    truth = Orbit(r_true, v_true, t0, propkw=propkw_from_cd_a_over_m(cd_true))
+    times = t0 + np.arange(0, 12 * 60 + 1, 30) * 60.0        # 12 h arc
+    r_ref, v_ref = rv(truth, times, propagator=prop)
+
+    # Start from a slightly WRONG epoch state (stale TLE / initial estimate).
+    dr, dv = np.array([150., -120., 90.]), np.array([0.12, -0.08, 0.10])
+    guess = Orbit(r_true + dr, v_true + dv, t0,
+                  propkw=propkw_from_cd_a_over_m(0.02))
+    print(f"\ntrue Cd*A/m = {cd_true:.3e} m^2/kg   "
+          f"initial state error |dr|={np.linalg.norm(dr):.0f} m, "
+          f"|dv|={np.linalg.norm(dv):.2f} m/s")
+
+    d = fit_drag(guess, times, r_ref, propagator=prop)
+    print("\ndrag-only (state frozen at the wrong guess):")
+    print(f"  Cd*A/m = {d['cd_a_over_m']:.3e}  "
+          f"({100*(d['cd_a_over_m']-cd_true)/cd_true:+.0f}%)   "
+          f"RMS(3D) {d['rms_after']:.1f} m")
+
+    j = fit_orbit_drag(guess, times, r_ref, v_ref=v_ref, propagator=prop)
+    print("\njoint (state + drag):")
+    print(f"  Cd*A/m = {j['cd_a_over_m']:.3e}  "
+          f"({100*(j['cd_a_over_m']-cd_true)/cd_true:+.2f}%)   "
+          f"RMS(3D) {j['rms_after']:.2e} m")
+    print(f"  recovered state error: |dr|={np.linalg.norm(j['r']-r_true):.2e} m, "
+          f"|dv|={np.linalg.norm(j['v']-v_true):.2e} m/s")
+    print("\nHolding a wrong state fixed forces the drag coefficient to absorb")
+    print("the state error. Solving for both recovers the true state and drag.")
+
+
 if __name__ == "__main__":
     demo_path_a()
     demo_path_b()
+    demo_joint_fit()

--- a/examples/tle_drag_paths.py
+++ b/examples/tle_drag_paths.py
@@ -1,0 +1,103 @@
+"""
+Two ways to use a TLE in SSAPy.
+
+Path A  -- exact SGP4 reproduction.
+    ``Orbit.fromTLETuple`` now retains the native SGP4 record (B* and the
+    mean-motion-rate terms), and ``SGP4Propagator`` propagates with it.  Output
+    matches direct ``sgp4.api.Satrec`` to machine precision, including for
+    drag-sensitive LEO objects such as the ISS.  This makes SSAPy a faithful
+    TLE-native baseline -- but note it is *calling* SGP4, not replacing it.
+
+Path B  -- physical numerical propagation seeded from the TLE.
+    A TLE gives only B*, which is tied to SGP4's reference atmosphere and is not
+    a physical ballistic coefficient.  ``ssapy.tle_drag`` seeds a physical
+    Cd*A/m from B* (rough) and fits it by orbit determination against a
+    reference arc so SSAPy's numerical force model (two-body + geopotential +
+    Sun/Moon + Harris-Priester drag) tracks that arc.  The result is a
+    *different* dynamical product: it does not equal SGP4 and must be validated
+    against truth (owner ephemeris / precise orbit), not against SGP4.
+
+Run:  python examples/tle_drag_paths.py
+"""
+
+import warnings
+import numpy as np
+from sgp4.api import Satrec
+from astropy.time import Time
+from astropy import units as u
+
+import ssapy
+from ssapy import Orbit
+from ssapy.propagator import SGP4Propagator
+from ssapy.compute import rv
+from ssapy.utils import teme_to_gcrf
+from ssapy.tle_drag import (bstar_to_cd_a_over_m, numerical_from_tle,
+                            _sgp4_reference_arc, fit_drag)
+
+warnings.filterwarnings("ignore")
+
+ISS = ("1 25544U 98067A   24015.54791435  .00016717  00000-0  30074-3 0  9993",
+       "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.49514637123456")
+GEO = ("1 41866U 16071A   24015.50000000 -.00000267  00000-0  00000+0 0  9990",
+       "2 41866   0.0177  86.6394 0001679 191.2716 168.7788  1.00272058 26978")
+
+
+def _direct_sgp4_gcrf(tle, dt_minutes):
+    sat = Satrec.twoline2rv(*tle)
+    t0 = Time(sat.jdsatepoch, format="jd") + sat.jdsatepochF * u.d
+    rs = []
+    for dt in dt_minutes:
+        _, r, _ = sat.sgp4_tsince(dt)
+        rs.append(np.array(r) * 1e3)  # km -> m, TEME
+    return (teme_to_gcrf(t0.gps) @ np.array(rs).T).T
+
+
+def demo_path_a():
+    print("=" * 68)
+    print("PATH A -- SSAPy SGP4Propagator vs direct sgp4 (should be ~0)")
+    print("=" * 68)
+    dts = [0.0, 60.0, 6 * 60.0, 12 * 60.0, 24 * 60.0]
+    for name, tle in [("ISS (LEO ~420 km, high drag)", ISS),
+                      ("GEO (negligible drag)", GEO)]:
+        ref = _direct_sgp4_gcrf(tle, dts)
+        orb = Orbit.fromTLETuple(tle)
+        prop = SGP4Propagator()
+        got = np.array([rv(orb, orb.t + dt * 60.0, propagator=prop)[0]
+                        for dt in dts])
+        err = np.linalg.norm(ref - got, axis=1)
+        print(f"\n{name}:")
+        for dt, e in zip(dts, err):
+            print(f"   t0 + {dt/60:5.1f} h : {e:.3e} m")
+
+
+def demo_path_b():
+    print("\n" + "=" * 68)
+    print("PATH B -- physical numerical propagation seeded/fit from a TLE")
+    print("=" * 68)
+    orb0, _ = _sgp4_reference_arc(ISS, [0.0])
+    t0 = orb0.t
+    times = t0 + np.arange(0, 24 * 60 + 1, 30) * 60.0     # 1 day, 30-min steps
+    _, r_ref = _sgp4_reference_arc(ISS, times)            # truth stand-in
+
+    seed = bstar_to_cd_a_over_m(orb0._sat.bstar)
+    print(f"\nCd*A/m seed from B*         : {seed:.4e} m^2/kg  (approximate)")
+
+    orb, prop = numerical_from_tle(ISS)                   # unfit, B* seed
+    r_seed = np.array([rv(orb, t, propagator=prop)[0] for t in times])
+    rms_seed = np.sqrt(np.mean(np.sum((r_seed - r_ref) ** 2, axis=1)))
+    print(f"numerical(seed) vs SGP4 arc : RMS(3D) {rms_seed:8.1f} m")
+
+    res = fit_drag(orb0, times, r_ref)
+    print(f"fit Cd*A/m                  : {res['cd_a_over_m']:.4e} m^2/kg")
+    print(f"numerical(fit)  vs SGP4 arc : RMS(3D) {res['rms_after']:8.1f} m"
+          f"   max {res['max_after']:8.1f} m")
+    print("\nThe fit residual is a floor set by the SGP4-vs-numerical model")
+    print("difference (Harris-Priester atmosphere, full force model), not by")
+    print("integration error -- so Path B is a distinct product, not an SGP4")
+    print("reproduction.  Validate it against real ephemeris, where it may")
+    print("outperform SGP4.")
+
+
+if __name__ == "__main__":
+    demo_path_a()
+    demo_path_b()

--- a/ssapy/compute.py
+++ b/ssapy/compute.py
@@ -52,6 +52,7 @@ def _countOrbit(orbit):
         if orbit.r.ndim == 1:  # scalar Orbit
             nOrbit = 1
             squeezeOrbit = True
+            _orig_scalar = orbit
             if 'kozaiMeanKeplerianElements' in orbit.__dict__:
                 kMKE = orbit.__dict__['kozaiMeanKeplerianElements']
             else:
@@ -67,6 +68,12 @@ def _countOrbit(orbit):
             # ought to retain other (all?) lazy_properties attributes too?
             if kMKE is not None:
                 orbit.kozaiMeanKeplerianElements = kMKE
+            # Preserve native SGP4 record (Path A) across scalar->vector
+            # promotion so SGP4Propagator can reproduce direct sgp4 exactly.
+            if hasattr(_orig_scalar, "_sat"):
+                orbit._sat = _orig_scalar._sat
+            if hasattr(_orig_scalar, "_tle"):
+                orbit._tle = _orig_scalar._tle
         else:  # vector Orbit
             nOrbit = orbit.r.shape[0]
             squeezeOrbit = False

--- a/ssapy/orbit.py
+++ b/ssapy/orbit.py
@@ -704,6 +704,12 @@ class Orbit:
             )
             if kMKE is not None:
                 out.kozaiMeanKeplerianElements = kMKE
+            # Preserve native SGP4 record (Path A) so a TLE-derived orbit
+            # reproduces direct sgp4 after scalar/vector round-trips.
+            if hasattr(self, "_sat"):
+                out._sat = self._sat
+            if hasattr(self, "_tle"):
+                out._tle = self._tle
             # TODO: iterate through already-instantiated lazy_properties and
             # copy them over too.
             self._iter += 1
@@ -720,6 +726,11 @@ class Orbit:
                     propkw={k: v[idx] for k, v in self.propkw.items()})
         if kMKE is not None:
             out.kozaiMeanKeplerianElements = kMKE
+        # Preserve native SGP4 record (Path A) on indexing.
+        if hasattr(self, "_sat"):
+            out._sat = self._sat
+        if hasattr(self, "_tle"):
+            out._tle = self._tle
         return out
 
     def __hash__(self):
@@ -1065,6 +1076,7 @@ class Orbit:
         Orbit
         """
         from .io import _rvt_from_tle_tuple, parse_tle
+        from sgp4.api import Satrec
         # Should set Kozai elements here directly from TLE.
         a, e, i, pa, raan, trueAnomaly, t = parse_tle(tle)
         r, v, t2 = _rvt_from_tle_tuple(tle)
@@ -1076,6 +1088,12 @@ class Orbit:
         obj = Orbit(r, v, t, mu=EARTH_MU)
         obj.kozaiMeanKeplerianElements = a, e, i, pa, raan, trueAnomaly
         obj.propkw = propkw if propkw is not None else dict()
+        # Path A: retain the native SGP4 record (and raw lines) so that
+        # SGP4Propagator can reproduce direct-sgp4 results exactly, including
+        # the drag (B*) and mean-motion-rate terms that parse_tle discards.
+        # These are the *only* faithful way to propagate a TLE.
+        obj._tle = tuple(tle)
+        obj._sat = Satrec.twoline2rv(tle[0], tle[1])
         return obj
 
     def at(self, t, propagator=_KeplerianPropagator()):

--- a/ssapy/propagator.py
+++ b/ssapy/propagator.py
@@ -192,17 +192,21 @@ class SGP4Propagator(Propagator):
     Parameters
     ----------
     t : float or astropy.time.Time, optional
-        Reference time at which to compute frame transformation between GCRF
+        Reference time at which to compute the frame transformation between GCRF
         and TEME.  SGP4 calculations occur in the TEME frame, but useful input
-        and output is in the GCRF frame.  In principle, one could do the
-        transformation at every instant in time for which the orbit is queried.
-        However, the rate of change in the transformation is small, ~0.15 arcsec
-        per day, so here we just use a single transformation.
+        and output is in the GCRF frame.
+
+        If None (default), the transformation is computed at every output time.
+        This is the correct treatment: the rate of change is small (~0.15 arcsec
+        per day) but not negligible for precise work, and using a single epoch
+        leaves a growing frame error of ~2 m/day at LEO and ~27 m/day at GEO.
+
+        If a time is supplied, a single transformation at that fixed epoch is
+        used for the whole arc (faster, but only approximate).  Pass the orbit
+        epoch here to recover the legacy single-transformation behaviour.
 
         If float, then should correspond to GPS seconds;
         i.e., seconds since 1980-01-06 00:00:00 UTC
-
-        If None, then use the time of the orbit being propagated.
     truncate : bool, optional
         Truncate elements to precision of TLE ASCII format?  This may be
         required in order to reproduce the results of running sgp4 directly from
@@ -269,10 +273,21 @@ class SGP4Propagator(Propagator):
             vs.append(v)
         rs = np.array(rs)
         vs = np.array(vs)
-        tref = self.t if self.t is not None else orbit.t
-        rot = teme_to_gcrf(tref)
-        rs = np.dot(rot, rs.T).T
-        vs = np.dot(rot, vs.T).T
+        # SGP4 output is TEME *of date*, so the TEME->GCRF precession-nutation
+        # rotation must be evaluated at each output time.  Using one epoch-time
+        # rotation for the whole arc leaves a slowly growing frame error
+        # (~2 m/day at LEO, ~27 m/day at GEO) that would masquerade as
+        # propagator error when comparing against a GCRF ephemeris.  When
+        # ``self.t`` is set the caller has explicitly asked for a single fixed
+        # reference epoch (faster, approximate); honour it.
+        if self.t is not None:
+            rot = teme_to_gcrf(self.t)
+            rs = np.dot(rot, rs.T).T
+            vs = np.dot(rot, vs.T).T
+        else:
+            rot = teme_to_gcrf(np.asarray(time, dtype=float))
+            rs = np.einsum("nij,nj->ni", rot, rs)
+            vs = np.einsum("nij,nj->ni", rot, vs)
         rs *= 1e3  # km -> m
         vs *= 1e3  # km/s -> m/s
         return rs, vs

--- a/ssapy/propagator.py
+++ b/ssapy/propagator.py
@@ -226,6 +226,14 @@ class SGP4Propagator(Propagator):
         if self.truncate:
             line1, line2 = make_tle(*orbit.kozaiMeanKeplerianElements, orbit.t)
             sat = Satrec.twoline2rv(line1, line2)
+        elif getattr(orbit, "_sat", None) is not None:
+            # Path A: the orbit was built from a TLE and still carries its
+            # native SGP4 record.  Propagating with it reproduces direct sgp4
+            # exactly, because B* and the mean-motion-rate terms are retained.
+            # (The reconstruction branch below rebuilds from drag-free Kozai
+            # elements with bstar=0 and therefore cannot match sgp4 for
+            # drag-sensitive LEO objects.)
+            sat = orbit._sat
         else:
             a, e, i, pa, raan, trueAnomaly = orbit.kozaiMeanKeplerianElements
             meanAnomaly = _ellipticalEccentricToMeanAnomaly(

--- a/ssapy/tle_drag.py
+++ b/ssapy/tle_drag.py
@@ -1,0 +1,239 @@
+"""
+Path B: physically-propagated orbits seeded from a TLE.
+
+A TLE is an SGP4 object: its mean elements and its B* drag term are defined
+*inside* the SGP4 theory and are only self-consistent when propagated by SGP4
+(see ``SGP4Propagator`` / ``Orbit.fromTLETuple`` for the exact-reproduction
+path, "Path A").
+
+This module supports the other case: taking a TLE as a starting point for
+SSAPy's *numerical* force model (two-body + geopotential + third bodies +
+Harris-Priester drag).  The result is a genuinely different -- and arguably
+higher-fidelity -- dynamical product.  It will NOT equal direct sgp4 and must
+not be validated against it; it is validated against truth (owner ephemerides,
+precise orbits, or an orbit-determination residual).
+
+Two things a TLE does not give you that the numerical drag model needs:
+
+1. A physical ballistic coefficient.  ``AccelDrag`` wants ``CD``, ``area``,
+   ``mass`` (it uses ``CD*area/mass``); a TLE carries only B*, which is scaled
+   to SGP4's *reference* atmosphere and is not transferable to Harris-Priester.
+   ``bstar_to_cd_a_over_m`` gives a rough SEED only.
+
+2. Model consistency.  The defensible way to pin the physical coefficient is
+   ``fit_drag`` -- estimate ``Cd*A/m`` (and optionally the epoch state) by
+   least squares against a reference arc.
+"""
+
+import numpy as np
+
+# SGP4 reference density used to map B* -> physical Cd*A/m.
+# B* = (Cd*A/m) * rho0 / 2   =>   Cd*A/m = 2*B* / rho0.
+# rho0 in kg/m^2/Earth-radius (Vallado, canonical->SI). This is only a seed:
+# B* is a fitted SGP4 parameter, not a physical ballistic coefficient, and the
+# SGP4 reference atmosphere differs from Harris-Priester used by AccelDrag.
+SGP4_RHO0 = 0.1570  # kg / m^2 / Earth-radius
+
+
+def bstar_to_cd_a_over_m(bstar, rho0=SGP4_RHO0):
+    """Rough physical drag ratio Cd*A/m [m^2/kg] implied by an SGP4 B* term.
+
+    Parameters
+    ----------
+    bstar : float
+        SGP4 B* drag term (as carried on ``Satrec.bstar``), units 1/Earth-radii.
+    rho0 : float, optional
+        SGP4 reference density [kg/m^2/Earth-radius]. Default ``SGP4_RHO0``.
+
+    Returns
+    -------
+    float
+        Cd*A/m in m^2/kg.
+
+    Notes
+    -----
+    Approximate and model-inconsistent -- use only as a starting guess for
+    ``fit_drag``. Non-positive B* (common for high or maneuvering objects)
+    yields a non-positive result and should be replaced by a physical prior.
+    """
+    return 2.0 * bstar / rho0
+
+
+def propkw_from_cd_a_over_m(cd_a_over_m, cr_a_over_m=0.0):
+    """Build a ``propkw`` dict encoding physical drag/SRP ratios.
+
+    ``AccelDrag`` uses ``CD*area/mass`` and ``AccelSolRad``/``AccelEarthRad``
+    use ``CR*area/mass``. By fixing ``area = mass = 1`` the ``CD`` and ``CR``
+    entries carry the full m^2/kg ratios directly, so only the physically
+    meaningful ratios need to be specified or fit.
+    """
+    return dict(area=1.0, mass=1.0,
+                CD=float(cd_a_over_m), CR=float(cr_a_over_m))
+
+
+def drag_propagator(harmonics=(4, 4), third_bodies=("sun", "moon"),
+                    ode_kwargs=None):
+    """Numerical propagator with two-body + geopotential + third bodies + drag.
+
+    Parameters
+    ----------
+    harmonics : 2-tuple of int, optional
+        (n, m) degree/order of the Earth geopotential. Default (4, 4).
+    third_bodies : iterable of str, optional
+        Third-body point-mass perturbers. Default sun and moon.
+    ode_kwargs : dict, optional
+        Overrides for the SciPy integrator (default DOP853, rtol 1e-9).
+
+    Returns
+    -------
+    SciPyPropagator
+    """
+    from functools import partial
+    from .accel import AccelKepler, AccelSum, AccelDrag
+    from .gravity import AccelHarmonic, AccelThirdBody
+    from .body import get_body
+    from .propagator import SciPyPropagator
+
+    earth = get_body("earth")
+    accels = [AccelKepler(earth.mu), AccelHarmonic(earth, *harmonics)]
+    for name in third_bodies:
+        accels.append(AccelThirdBody(get_body(name)))
+    accels.append(AccelDrag())
+    accel = AccelSum(accels)
+
+    if ode_kwargs is None:
+        ode_kwargs = dict(method="DOP853", rtol=1e-9,
+                          atol=(1e-1, 1e-1, 1e-1, 1e-4, 1e-4, 1e-4))
+    return partial(SciPyPropagator, ode_kwargs=ode_kwargs)(accel)
+
+
+def numerical_from_tle(tle, cd_a_over_m=None, cr_a_over_m=0.0,
+                       harmonics=(4, 4), propagator=None):
+    """Build an ``Orbit`` (epoch state from the TLE) plus a drag propagator.
+
+    Parameters
+    ----------
+    tle : 2-tuple of str
+        Line1, Line2.
+    cd_a_over_m : float, optional
+        Physical Cd*A/m [m^2/kg]. If None, seeded from B* via
+        ``bstar_to_cd_a_over_m`` (approximate -- prefer ``fit_drag``).
+    cr_a_over_m : float, optional
+        Physical Cr*A/m [m^2/kg] for SRP. Default 0 (drag only).
+    harmonics : 2-tuple of int, optional
+        Geopotential degree/order. Default (4, 4).
+    propagator : Propagator, optional
+        Prebuilt propagator; if None one is created via ``drag_propagator``.
+
+    Returns
+    -------
+    orbit : Orbit
+        Epoch state (GCRF) with ``propkw`` populated.
+    propagator : Propagator
+    """
+    from .orbit import Orbit
+
+    orbit = Orbit.fromTLETuple(tle)
+    if cd_a_over_m is None:
+        cd_a_over_m = bstar_to_cd_a_over_m(orbit._sat.bstar)
+    orbit.propkw = propkw_from_cd_a_over_m(cd_a_over_m, cr_a_over_m)
+    if propagator is None:
+        propagator = drag_propagator(harmonics=harmonics)
+    return orbit, propagator
+
+
+def _sgp4_reference_arc(tle, times):
+    """Reference GCRF positions from the TLE's own SGP4 over ``times``.
+
+    Convenience truth stand-in for demos/tests. For a real product, pass owner
+    ephemeris or a precise orbit as the reference instead -- fitting a physical
+    model to SGP4 output is only a pipeline demonstration.
+    """
+    from .orbit import Orbit
+    from .propagator import SGP4Propagator
+    from .compute import rv
+    orbit = Orbit.fromTLETuple(tle)               # Path A: native Satrec
+    prop = SGP4Propagator()
+    r = np.array([rv(orbit, t, propagator=prop)[0] for t in times])
+    return orbit, r
+
+
+def fit_drag(orbit, times, r_ref, propagator=None, harmonics=(4, 4),
+             cd_a_over_m0=None, bounds=(1e-6, 1.0), verbose=False):
+    """Fit physical Cd*A/m so numerical propagation matches a reference arc.
+
+    This is the defensible way to give a TLE-seeded numerical orbit a physical
+    drag coefficient: solve for the single scalar Cd*A/m [m^2/kg] that minimizes
+    position residuals of the full numerical force model against ``r_ref``.
+
+    Parameters
+    ----------
+    orbit : Orbit
+        Epoch state (e.g. from ``Orbit.fromTLETuple``).
+    times : array_like (m,)
+        GPS seconds at which the reference is sampled.
+    r_ref : array_like (m, 3)
+        Reference GCRF positions [m] (owner ephemeris / precise orbit; or, for
+        a demo, ``_sgp4_reference_arc`` output).
+    propagator : Propagator, optional
+        Drag propagator; built via ``drag_propagator`` if None.
+    harmonics : 2-tuple of int, optional
+        Geopotential degree/order for the built propagator. Default (4, 4).
+    cd_a_over_m0 : float, optional
+        Initial guess [m^2/kg]. If None and the orbit carries a native Satrec,
+        seeded from B*; otherwise 0.02.
+    bounds : 2-tuple, optional
+        (lower, upper) bounds on Cd*A/m for the solver.
+    verbose : bool, optional
+        Print the residual per iteration.
+
+    Returns
+    -------
+    dict
+        ``cd_a_over_m`` (fit), ``propkw``, ``orbit`` (copy with propkw set),
+        ``propagator``, ``rms_before`` and ``rms_after`` (RMS 3D position error
+        [m] at the seed vs the fit), and ``max_after`` (max error [m]).
+    """
+    from scipy.optimize import least_squares
+    from .compute import rv
+
+    times = np.asarray(times, dtype=float)
+    r_ref = np.asarray(r_ref, dtype=float)
+    if propagator is None:
+        propagator = drag_propagator(harmonics=harmonics)
+
+    if cd_a_over_m0 is None:
+        sat = getattr(orbit, "_sat", None)
+        seed = bstar_to_cd_a_over_m(sat.bstar) if sat is not None else 0.02
+        cd_a_over_m0 = seed if bounds[0] < seed < bounds[1] else 0.02
+
+    def _propagate(cd):
+        orbit.propkw = propkw_from_cd_a_over_m(cd)
+        r = np.array([rv(orbit, t, propagator=propagator)[0] for t in times])
+        return r
+
+    def _rms3d(r):
+        return float(np.sqrt(np.mean(np.sum((r - r_ref) ** 2, axis=1))))
+
+    def resid(p):
+        r = _propagate(p[0])
+        if verbose:
+            print(f"  Cd*A/m={p[0]:.5e}  rms(3D)={_rms3d(r):.1f} m")
+        return (r - r_ref).ravel()
+
+    rms_before = _rms3d(_propagate(cd_a_over_m0))
+
+    opt = least_squares(resid, [cd_a_over_m0],
+                        bounds=([bounds[0]], [bounds[1]]),
+                        xtol=1e-12, ftol=1e-12)
+    cd_fit = float(opt.x[0])
+
+    r_fit = _propagate(cd_fit)
+    err = np.linalg.norm(r_fit - r_ref, axis=1)
+    rms_after = float(np.sqrt(np.mean(err ** 2)))
+
+    propkw = propkw_from_cd_a_over_m(cd_fit)
+    orbit.propkw = dict(propkw)
+    return dict(cd_a_over_m=cd_fit, propkw=propkw, orbit=orbit,
+                propagator=propagator, rms_before=rms_before,
+                rms_after=rms_after, max_after=float(err.max()))

--- a/ssapy/tle_drag.py
+++ b/ssapy/tle_drag.py
@@ -209,7 +209,7 @@ def fit_drag(orbit, times, r_ref, propagator=None, harmonics=(4, 4),
 
     def _propagate(cd):
         orbit.propkw = propkw_from_cd_a_over_m(cd)
-        r = np.array([rv(orbit, t, propagator=propagator)[0] for t in times])
+        r, _ = rv(orbit, times, propagator=propagator)  # one integration, dense
         return r
 
     def _rms3d(r):
@@ -237,3 +237,156 @@ def fit_drag(orbit, times, r_ref, propagator=None, harmonics=(4, 4),
     return dict(cd_a_over_m=cd_fit, propkw=propkw, orbit=orbit,
                 propagator=propagator, rms_before=rms_before,
                 rms_after=rms_after, max_after=float(err.max()))
+
+
+def _rms3d(r, r_ref):
+    """RMS 3D position error [m] between two (N, 3) arrays."""
+    return float(np.sqrt(np.mean(np.sum((np.asarray(r) - np.asarray(r_ref)) ** 2,
+                                        axis=1))))
+
+
+def fit_orbit_drag(orbit, times, r_ref, v_ref=None, propagator=None,
+                   harmonics=(4, 4), cd_a_over_m0=None, solve_drag=True,
+                   cd_bounds=(1e-6, 1.0), pos_sigma=1.0, vel_sigma=1e-3,
+                   return_cov=False, verbose=False):
+    """Joint orbit-determination fit of the epoch state *and* the drag coefficient.
+
+    ``fit_drag`` solves for a single scalar ``Cd*A/m`` while holding the epoch
+    state fixed at the input orbit.  If that state is even slightly wrong (a
+    stale TLE, an initial guess, a maneuvering object), the state error is
+    absorbed into the fitted drag coefficient and biases it.  This routine
+    estimates the full 6-element GCRF epoch state (position + velocity) together
+    with ``Cd*A/m`` by least squares against a reference arc, so the two are
+    separated.
+
+    The forward model is the numerical propagator (two-body + geopotential +
+    Sun/Moon + Harris-Priester drag).  Position residuals are always used;
+    velocity residuals are added when ``v_ref`` is supplied.  Parameters are
+    internally scaled by their characteristic magnitudes so the very different
+    units (m, m/s, m^2/kg) stay well-conditioned.
+
+    Parameters
+    ----------
+    orbit : Orbit
+        Initial guess for the epoch state (e.g. from ``Orbit.fromTLETuple``).
+    times : array_like (m,)
+        GPS seconds at which the reference is sampled.  Should span a long
+        enough arc for drag to be observable (hours to a day at LEO).
+    r_ref : array_like (m, 3)
+        Reference GCRF positions [m] (owner ephemeris / precise orbit).
+    v_ref : array_like (m, 3), optional
+        Reference GCRF velocities [m/s].  If given, included in the fit.
+    propagator : Propagator, optional
+        Drag propagator; built via ``drag_propagator`` if None.
+    harmonics : 2-tuple of int, optional
+        Geopotential degree/order for the built propagator. Default (4, 4).
+    cd_a_over_m0 : float, optional
+        Initial ``Cd*A/m`` [m^2/kg]. Seeded from B* if None and available,
+        else 0.02.
+    solve_drag : bool, optional
+        If True (default) fit ``Cd*A/m`` jointly with the state (7 parameters);
+        if False fit only the 6-element state at fixed ``cd_a_over_m0``.
+    cd_bounds : 2-tuple, optional
+        (lower, upper) bounds on ``Cd*A/m``.
+    pos_sigma, vel_sigma : float, optional
+        Measurement 1-sigma for position [m] and velocity [m/s].  Only their
+        ratio matters for the fit; they also set the scale of ``cov``.
+    return_cov : bool, optional
+        If True, include the parameter covariance matrix in the result.
+    verbose : bool, optional
+        Print the 3D position RMS each iteration.
+
+    Returns
+    -------
+    dict
+        ``orbit`` (fitted epoch state as an Orbit), ``r`` / ``v`` (fitted epoch
+        position/velocity), ``cd_a_over_m``, ``propkw``, ``rms_before`` /
+        ``rms_after`` (3D position RMS [m] at the initial guess vs the fit),
+        ``max_after`` [m], ``success``, ``nfev``, and (if requested) ``cov``:
+        the parameter covariance ordered [x, y, z, vx, vy, vz, (Cd*A/m)].
+    """
+    from scipy.optimize import least_squares
+    from .orbit import Orbit
+    from .compute import rv
+
+    times = np.asarray(times, dtype=float)
+    r_ref = np.asarray(r_ref, dtype=float)
+    if v_ref is not None:
+        v_ref = np.asarray(v_ref, dtype=float)
+    if propagator is None:
+        propagator = drag_propagator(harmonics=harmonics)
+
+    t0 = orbit.t
+    mu = orbit.mu
+    r0 = np.asarray(orbit.r, dtype=float).ravel().copy()
+    v0 = np.asarray(orbit.v, dtype=float).ravel().copy()
+
+    if cd_a_over_m0 is None:
+        sat = getattr(orbit, "_sat", None)
+        seed = bstar_to_cd_a_over_m(sat.bstar) if sat is not None else 0.02
+        cd_a_over_m0 = seed if cd_bounds[0] < seed < cd_bounds[1] else 0.02
+
+    Lr = float(np.linalg.norm(r0)) or 1.0
+    Lv = float(np.linalg.norm(v0)) or 1.0
+
+    def _unpack(p):
+        r = p[0:3]
+        v = p[3:6]
+        cd = p[6] if solve_drag else cd_a_over_m0
+        return r, v, cd
+
+    def _model(p):
+        r, v, cd = _unpack(p)
+        o = Orbit(r, v, t0, mu=mu, propkw=propkw_from_cd_a_over_m(cd))
+        return rv(o, times, propagator=propagator)   # (m,3), (m,3)
+
+    def _resid(p):
+        rm, vm = _model(p)
+        res = ((rm - r_ref) / pos_sigma).ravel()
+        if v_ref is not None:
+            res = np.concatenate([res, ((vm - v_ref) / vel_sigma).ravel()])
+        if verbose:
+            print(f"  rms(3D pos) = {_rms3d(rm, r_ref):.3f} m")
+        return res
+
+    if solve_drag:
+        p0 = np.concatenate([r0, v0, [cd_a_over_m0]])
+        x_scale = np.array([Lr, Lr, Lr, Lv, Lv, Lv, cd_a_over_m0])
+        lb = [-np.inf] * 6 + [cd_bounds[0]]
+        ub = [np.inf] * 6 + [cd_bounds[1]]
+    else:
+        p0 = np.concatenate([r0, v0])
+        x_scale = np.array([Lr, Lr, Lr, Lv, Lv, Lv])
+        lb = [-np.inf] * 6
+        ub = [np.inf] * 6
+
+    rms_before = _rms3d(_model(p0)[0], r_ref)
+
+    opt = least_squares(_resid, p0, bounds=(lb, ub), x_scale=x_scale,
+                        method="trf", xtol=1e-12, ftol=1e-12)
+
+    r_fit, v_fit, cd_fit = _unpack(opt.x)
+    rm_fit, _ = _model(opt.x)
+    err = np.linalg.norm(rm_fit - r_ref, axis=1)
+
+    out = Orbit(r_fit, v_fit, t0, mu=mu,
+                propkw=propkw_from_cd_a_over_m(cd_fit))
+    result = dict(orbit=out, r=np.asarray(r_fit), v=np.asarray(v_fit),
+                  cd_a_over_m=float(cd_fit),
+                  propkw=propkw_from_cd_a_over_m(cd_fit),
+                  rms_before=rms_before, rms_after=float(np.sqrt(np.mean(err**2))),
+                  max_after=float(err.max()), success=bool(opt.success),
+                  nfev=int(opt.nfev))
+
+    if return_cov:
+        # Empirical parameter covariance: (J^T J)^-1 scaled by the reduced
+        # residual variance (matches scipy.optimize.curve_fit).  Robust to
+        # weak observability via the pseudo-inverse.
+        try:
+            J = opt.jac
+            dof = max(1, J.shape[0] - J.shape[1])
+            resid_var = 2.0 * opt.cost / dof
+            result["cov"] = np.linalg.pinv(J.T @ J) * resid_var
+        except Exception:
+            result["cov"] = None
+    return result

--- a/ssapy/utils.py
+++ b/ssapy/utils.py
@@ -1315,7 +1315,12 @@ def gcrf_to_teme(t):
     gst = erfa.gmst82(2400000.5, ut1)
     era = erfa.era00(2400000.5, ut1)
     c2i = erfa.c2i00b(2400000.5, mjd_tt)
-    return erfa.rxr(erfa.rv2m([0, 0, era - gst]), c2i)
+    # Equation-of-origins rotation vector [0, 0, era - gst].  Build it as a
+    # (..., 3) array so this works for scalar *and* array-valued t; a Python
+    # list [0, 0, era - gst] is ragged (and raises) when era - gst is an array.
+    w = np.zeros(np.shape(era) + (3,))
+    w[..., 2] = era - gst
+    return erfa.rxr(erfa.rv2m(w), c2i)
 
 
 def teme_to_gcrf(t):

--- a/tests/test_frame_perstep.py
+++ b/tests/test_frame_perstep.py
@@ -1,0 +1,66 @@
+import warnings
+
+import numpy as np
+import pytest
+from sgp4.api import Satrec
+from astropy.time import Time
+from astropy import units as u
+
+from ssapy import Orbit
+from ssapy.propagator import SGP4Propagator
+from ssapy.compute import rv
+from ssapy.utils import teme_to_gcrf
+
+ISS = ("1 25544U 98067A   24015.54791435  .00016717  00000-0  30074-3 0  9993",
+       "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.49514637123456")
+GEO = ("1 41866U 16071A   24015.50000000 -.00000267  00000-0  00000+0 0  9990",
+       "2 41866   0.0177  86.6394 0001679 191.2716 168.7788  1.00272058 26978")
+
+
+def test_teme_to_gcrf_accepts_time_array():
+    """teme_to_gcrf must vectorize over time and match a scalar loop exactly."""
+    t = 1.1e9 + np.array([0.0, 3600.0, 7200.0, 43200.0])
+    stacked = teme_to_gcrf(t)
+    assert stacked.shape == (4, 3, 3)
+    loop = np.array([teme_to_gcrf(ti) for ti in t])
+    assert np.array_equal(stacked, loop)
+    assert teme_to_gcrf(t[0]).shape == (3, 3)   # scalar unchanged
+
+
+def _astropy_teme_to_gcrf(tle, gps):
+    """Independent TEME->GCRF via astropy, per output time (ground truth)."""
+    coords = pytest.importorskip("astropy.coordinates")
+    TEME = coords.TEME
+    from astropy.coordinates import GCRS, CartesianRepresentation
+    sat = Satrec.twoline2rv(*tle)
+    epoch = Time(sat.jdsatepoch, format="jd") + sat.jdsatepochF * u.d
+    r_teme = np.array([np.array(sat.sgp4_tsince((g - epoch.gps) / 60.0)[1])
+                       for g in gps])  # km, TEME
+    obst = Time(gps, format="gps")
+    teme = TEME(CartesianRepresentation(r_teme.T * u.km), obstime=obst)
+    gcrf = teme.transform_to(GCRS(obstime=obst)).cartesian.xyz.T.to(u.km).value
+    return gcrf * 1e3  # m
+
+
+@pytest.mark.parametrize("tle,single_epoch_floor", [(ISS, 1.0), (GEO, 10.0)])
+def test_per_timestep_beats_single_epoch_vs_astropy(tle, single_epoch_floor):
+    """The default (per-timestep) frame handling agrees with astropy far better
+    than the single-epoch approximation over a 12 h arc."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        orb = Orbit.fromTLETuple(tle)
+        gps = orb.t + np.array([0.0, 1.0, 3.0, 6.0, 12.0]) * 3600.0
+        ref = _astropy_teme_to_gcrf(tle, gps)
+
+        per_step = np.array([rv(orb, g, propagator=SGP4Propagator())[0]
+                             for g in gps])
+        single = np.array([rv(orb, g, propagator=SGP4Propagator(t=orb.t))[0]
+                           for g in gps])
+
+    e_step = np.linalg.norm(per_step - ref, axis=1)
+    e_single = np.linalg.norm(single - ref, axis=1)
+    # per-timestep tracks astropy to well under a metre (IAU-model floor)
+    assert e_step.max() < 0.5
+    # and is dramatically better than single-epoch by the end of the arc
+    assert e_single.max() > single_epoch_floor
+    assert e_step.max() < 0.1 * e_single.max()

--- a/tests/test_tle_drag.py
+++ b/tests/test_tle_drag.py
@@ -1,4 +1,5 @@
 import warnings
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -6,12 +7,31 @@ from sgp4.api import Satrec
 from astropy.time import Time
 from astropy import units as u
 
+import ssapy
 from ssapy import Orbit
 from ssapy.propagator import SGP4Propagator
 from ssapy.compute import rv
 from ssapy.utils import teme_to_gcrf
 from ssapy.tle_drag import (bstar_to_cd_a_over_m, numerical_from_tle,
                             _sgp4_reference_arc, fit_drag)
+
+
+def _is_lfs_pointer(path):
+    try:
+        with open(path, "rb") as f:
+            return f.readline().startswith(b"version https://git-lfs.github.com/spec/v1")
+    except Exception:
+        return False
+
+
+# The numerical drag propagator needs the (Git LFS) gravity + ephemeris data,
+# which is absent in CI; skip those tests there, as tests/test_accel.py does.
+HAS_EGM84 = not _is_lfs_pointer(Path(ssapy.datadir) / "egm84.egm.cof")
+HAS_DE430 = not _is_lfs_pointer(Path(ssapy.datadir) / "de430.bsp")
+HAS_MOON_PA = not _is_lfs_pointer(Path(ssapy.datadir) / "moon_pa_de440_200625.bpc")
+HAS_BODY_DATA = HAS_EGM84 and HAS_DE430 and HAS_MOON_PA
+needs_body_data = pytest.mark.skipif(
+    not HAS_BODY_DATA, reason="body data unavailable (Git LFS pointer)")
 
 ISS = ("1 25544U 98067A   24015.54791435  .00016717  00000-0  30074-3 0  9993",
        "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.49514637123456")
@@ -66,6 +86,7 @@ def test_bstar_seed_is_physical_order():
     assert 1e-4 < cd < 1e-1
 
 
+@needs_body_data
 def test_path_b_fit_improves_residual():
     """Path B: fitting Cd*A/m against an arc reduces the residual and yields a
     sane physical coefficient (short arc for test speed)."""
@@ -101,6 +122,7 @@ def _light_drag_propagator():
                                            atol=(1e-2,) * 3 + (1e-5,) * 3))
 
 
+@needs_body_data
 def test_joint_fit_recovers_state_and_drag():
     """With a wrong epoch state, drag-only absorbs the error into Cd*A/m; the
     joint fit recovers the true state and coefficient instead."""
@@ -132,6 +154,7 @@ def test_joint_fit_recovers_state_and_drag():
     assert joint["cov"].shape == (7, 7)
 
 
+@needs_body_data
 def test_joint_fit_state_only_mode():
     """solve_drag=False fits the 6-element state at fixed drag (6 parameters)."""
     from ssapy.tle_drag import propkw_from_cd_a_over_m, fit_orbit_drag

--- a/tests/test_tle_drag.py
+++ b/tests/test_tle_drag.py
@@ -22,11 +22,10 @@ GEO = ("1 41866U 16071A   24015.50000000 -.00000267  00000-0  00000+0 0  9990",
 def _direct_sgp4_gcrf(tle, dt_minutes):
     sat = Satrec.twoline2rv(*tle)
     t0 = Time(sat.jdsatepoch, format="jd") + sat.jdsatepochF * u.d
-    rs = []
-    for dt in dt_minutes:
-        _, r, _ = sat.sgp4_tsince(dt)
-        rs.append(np.array(r) * 1e3)
-    return (teme_to_gcrf(t0.gps) @ np.array(rs).T).T
+    gps = t0.gps + np.asarray(dt_minutes, dtype=float) * 60.0
+    rs = np.array([np.array(sat.sgp4_tsince(dt)[1]) * 1e3 for dt in dt_minutes])
+    rot = teme_to_gcrf(gps)                      # per-output-time (vectorized)
+    return np.einsum("nij,nj->ni", rot, rs)
 
 
 def test_fromtletuple_retains_satrec():

--- a/tests/test_tle_drag.py
+++ b/tests/test_tle_drag.py
@@ -79,3 +79,73 @@ def test_path_b_fit_improves_residual():
     assert res["rms_after"] <= res["rms_before"]
     assert 1e-4 < res["cd_a_over_m"] < 1e-1
     assert set(res["propkw"]) == {"area", "mass", "CD", "CR"}
+
+
+def _numerical_truth_arc(propagator, cd_true, hours=6, step_min=60):
+    """Self-consistent numerical truth arc from the ISS epoch state."""
+    from ssapy.tle_drag import propkw_from_cd_a_over_m
+    o0 = Orbit.fromTLETuple(ISS)
+    t0 = o0.t
+    r_true = np.asarray(o0.r)
+    v_true = np.asarray(o0.v)
+    truth = Orbit(r_true, v_true, t0, propkw=propkw_from_cd_a_over_m(cd_true))
+    times = t0 + np.arange(0, hours * 60 + 1, step_min) * 60.0
+    r_ref, v_ref = rv(truth, times, propagator=propagator)
+    return t0, r_true, v_true, times, r_ref, v_ref
+
+
+def _light_drag_propagator():
+    from ssapy.tle_drag import drag_propagator
+    return drag_propagator(harmonics=(2, 2),
+                           ode_kwargs=dict(method="DOP853", rtol=1e-8,
+                                           atol=(1e-2,) * 3 + (1e-5,) * 3))
+
+
+def test_joint_fit_recovers_state_and_drag():
+    """With a wrong epoch state, drag-only absorbs the error into Cd*A/m; the
+    joint fit recovers the true state and coefficient instead."""
+    from ssapy.tle_drag import (propkw_from_cd_a_over_m, fit_drag,
+                                fit_orbit_drag)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        prop = _light_drag_propagator()
+        cd_true = 5.0e-3
+        t0, r_true, v_true, times, r_ref, v_ref = _numerical_truth_arc(
+            prop, cd_true, hours=6, step_min=60)
+        guess = Orbit(r_true + np.array([150., -120., 90.]),
+                      v_true + np.array([0.12, -0.08, 0.10]), t0,
+                      propkw=propkw_from_cd_a_over_m(0.02))
+        drag_only = fit_drag(guess, times, r_ref, propagator=prop)
+        joint = fit_orbit_drag(guess, times, r_ref, v_ref=v_ref,
+                               propagator=prop, return_cov=True)
+
+    # joint recovers the true epoch state and drag coefficient
+    assert np.linalg.norm(joint["r"] - r_true) < 1.0        # < 1 m
+    assert np.linalg.norm(joint["v"] - v_true) < 1e-3       # < 1 mm/s
+    assert abs(joint["cd_a_over_m"] - cd_true) / cd_true < 1e-2   # < 1%
+    assert joint["rms_after"] < 1.0                          # sub-metre
+    # joint beats drag-only, which cannot fit a wrong frozen state
+    assert joint["rms_after"] < drag_only["rms_after"]
+    assert (abs(joint["cd_a_over_m"] - cd_true) <
+            abs(drag_only["cd_a_over_m"] - cd_true))
+    # covariance returned with the right shape
+    assert joint["cov"].shape == (7, 7)
+
+
+def test_joint_fit_state_only_mode():
+    """solve_drag=False fits the 6-element state at fixed drag (6 parameters)."""
+    from ssapy.tle_drag import propkw_from_cd_a_over_m, fit_orbit_drag
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        prop = _light_drag_propagator()
+        cd_true = 5.0e-3
+        t0, r_true, v_true, times, r_ref, v_ref = _numerical_truth_arc(
+            prop, cd_true, hours=4, step_min=60)
+        guess = Orbit(r_true + np.array([120., -90., 60.]),
+                      v_true + np.array([0.10, -0.06, 0.08]), t0,
+                      propkw=propkw_from_cd_a_over_m(cd_true))
+        res = fit_orbit_drag(guess, times, r_ref, propagator=prop,
+                             solve_drag=False, cd_a_over_m0=cd_true)
+    assert res["cd_a_over_m"] == cd_true                     # drag held fixed
+    assert np.linalg.norm(res["r"] - r_true) < 1.0
+    assert "cov" not in res                                  # not requested

--- a/tests/test_tle_drag.py
+++ b/tests/test_tle_drag.py
@@ -1,0 +1,82 @@
+import warnings
+
+import numpy as np
+import pytest
+from sgp4.api import Satrec
+from astropy.time import Time
+from astropy import units as u
+
+from ssapy import Orbit
+from ssapy.propagator import SGP4Propagator
+from ssapy.compute import rv
+from ssapy.utils import teme_to_gcrf
+from ssapy.tle_drag import (bstar_to_cd_a_over_m, numerical_from_tle,
+                            _sgp4_reference_arc, fit_drag)
+
+ISS = ("1 25544U 98067A   24015.54791435  .00016717  00000-0  30074-3 0  9993",
+       "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.49514637123456")
+GEO = ("1 41866U 16071A   24015.50000000 -.00000267  00000-0  00000+0 0  9990",
+       "2 41866   0.0177  86.6394 0001679 191.2716 168.7788  1.00272058 26978")
+
+
+def _direct_sgp4_gcrf(tle, dt_minutes):
+    sat = Satrec.twoline2rv(*tle)
+    t0 = Time(sat.jdsatepoch, format="jd") + sat.jdsatepochF * u.d
+    rs = []
+    for dt in dt_minutes:
+        _, r, _ = sat.sgp4_tsince(dt)
+        rs.append(np.array(r) * 1e3)
+    return (teme_to_gcrf(t0.gps) @ np.array(rs).T).T
+
+
+def test_fromtletuple_retains_satrec():
+    """Path A: the native SGP4 record and B* survive construction."""
+    orb = Orbit.fromTLETuple(ISS)
+    assert hasattr(orb, "_sat")
+    assert hasattr(orb, "_tle")
+    assert orb._sat.bstar == pytest.approx(3.0074e-4, rel=1e-6)
+
+
+@pytest.mark.parametrize("tle", [ISS, GEO])
+def test_path_a_matches_direct_sgp4(tle):
+    """Path A reproduces direct sgp4 to sub-mm, including drag-sensitive LEO."""
+    dts = [0.0, 60.0, 6 * 60.0, 12 * 60.0, 24 * 60.0]
+    ref = _direct_sgp4_gcrf(tle, dts)
+    orb = Orbit.fromTLETuple(tle)
+    prop = SGP4Propagator()
+    got = np.array([rv(orb, orb.t + dt * 60.0, propagator=prop)[0]
+                    for dt in dts])
+    err = np.linalg.norm(ref - got, axis=1)
+    assert err.max() < 1e-3  # < 1 mm over a full day
+
+
+def test_path_a_survives_scalar_vector_promotion():
+    """_sat must survive scalar->vector->scalar round-trips, since compute.rv
+    promotes a scalar Orbit internally before propagating."""
+    from ssapy.compute import _countOrbit
+    orb = Orbit.fromTLETuple(ISS)
+    _, _, promoted = _countOrbit(orb)      # scalar -> vector
+    assert hasattr(promoted, "_sat")
+    assert next(iter(promoted)).__dict__.get("_sat") is not None  # vector -> scalar
+
+
+def test_bstar_seed_is_physical_order():
+    """B* -> Cd*A/m seed lands in a physically plausible range."""
+    orb = Orbit.fromTLETuple(ISS)
+    cd = bstar_to_cd_a_over_m(orb._sat.bstar)
+    assert 1e-4 < cd < 1e-1
+
+
+def test_path_b_fit_improves_residual():
+    """Path B: fitting Cd*A/m against an arc reduces the residual and yields a
+    sane physical coefficient (short arc for test speed)."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        orb0, _ = _sgp4_reference_arc(ISS, [0.0])
+        t0 = orb0.t
+        times = t0 + np.arange(0, 3 * 60 + 1, 30) * 60.0   # 3 h, 30-min steps
+        _, r_ref = _sgp4_reference_arc(ISS, times)
+        res = fit_drag(orb0, times, r_ref)
+    assert res["rms_after"] <= res["rms_before"]
+    assert 1e-4 < res["cd_a_over_m"] < 1e-1
+    assert set(res["propkw"]) == {"area", "mass", "CD", "CR"}


### PR DESCRIPTION
## Make TLE propagation faithful, add drag fitting, and fix a frame approximation

### What this does
When you load a TLE (two-line element set) into SSAPy today, the drag
information in it is thrown away, so propagating a TLE drifts away from the
standard SGP4 result — about 7 km/day for the ISS. This PR fixes that and adds
two related capabilities, plus a documentation refresh. Each of the five commits
stands on its own.

Three things change:

1. **TLEs now propagate exactly like standard SGP4.** Load a TLE, get the same
   answer the reference SGP4 library gives — including the drag term.
2. **A new physics-based option for TLEs, with orbit fitting.** Instead of SGP4,
   you can propagate a TLE through SSAPy's full numerical force model and fit the
   satellite's drag (and, if you want, its state) to real tracking data.
3. **A more accurate coordinate-frame conversion** in the SGP4 propagator.

---

### 1. Faithful SGP4 from a TLE
A TLE carries a drag term (`B*`) and mean-motion rates. SSAPy was discarding
them and propagating from drag-free elements, so results diverged from SGP4 —
worst for low, high-drag objects.

**Fix:** keep the original SGP4 record when a TLE is loaded and propagate with
it directly. `Orbit.fromTLETuple` now stores the parsed SGP4 record; the SGP4
propagator uses it when present (the old reconstruction path stays as a
fallback). The record is preserved when an orbit is indexed or iterated, which
is where it was previously being dropped.

Result — position error vs the reference SGP4 library:

| object | before | after |
|---|---|---|
| ISS (low Earth orbit, ~420 km) | 7153 m at 24 h | ~1e-9 m |
| geostationary | ~20 m at 24 h | ~1e-9 m |

This makes a TLE-loaded orbit a faithful SGP4 baseline. Note it is *running*
SGP4, not independently reproducing it.

---

### 2. Physics-based propagation and drag fitting for TLEs (`ssapy.tle_drag`)
The alternative to SGP4: take a TLE as a starting point and propagate it through
SSAPy's numerical force model (gravity + Sun/Moon + atmospheric drag). This is a
genuinely different, higher-fidelity model — it does **not** reproduce SGP4 and
should be checked against real tracking data, not against SGP4.

A TLE doesn't give you a physical drag coefficient (its `B*` is tied to SGP4's
internal atmosphere), so this module estimates one:

- **`fit_drag`** — solves for the satellite's drag coefficient (Cd·A/m) so the
  numerical propagation matches a reference orbit track.
- **`fit_orbit_drag`** — a full orbit-determination fit that solves for the
  satellite's **position, velocity, and drag together**. This matters because if
  the starting position is even slightly off and you only fit drag, the position
  error gets absorbed into the drag number and corrupts it. Fitting everything at
  once separates them.

Demonstration on a known test case (starting position deliberately off by ~210 m
and 0.18 m/s; true drag coefficient 5e-3):

| approach | recovered drag coefficient | track fit |
|---|---|---|
| fit drag only (position held fixed) | 0.327 — off by +6400% | stuck at ~1.7 km error |
| fit position + drag together | 5.0e-3 — essentially exact | ~1e-7 m error |

Helpers included: convert `B*` to a starting drag estimate, build the numerical
propagator, and (optionally) return the fit's uncertainty covariance for
downstream filtering. `fit_drag` was also sped up to integrate an orbit once
across all requested times instead of re-integrating for each one.

---

### 3. Time-accurate TEME→GCRF conversion
SGP4 produces coordinates in the TEME frame; SSAPy converts them to the standard
GCRF/GCRS frame. The propagator was computing that rotation **once, at the start
time**, and reusing it for the whole arc. Because the rotation drifts slowly over
time, this leaves a small error that grows — and grows with orbit size.

**Fix:** compute the rotation at each output time. Checked against Astropy's
independent implementation:

| object | old (single time) at 12 h | new (per time step) |
|---|---|---|
| ISS | 2.2 m | ~0.01 m |
| geostationary | 13.5 m (26.5 m at 24 h) | ~0.05 m |

Also fixes the underlying conversion so it accepts an array of times (it silently
failed on arrays before); single-time results are bit-for-bit identical.

> **Behavior change for existing users:** `SGP4Propagator()` now does the
> per-time-step conversion by default. Output shifts by up to a few tens of
> meters at geostationary altitude compared to before. This is the more correct
> behavior. To get the old single-time behavior, pass the epoch:
> `SGP4Propagator(t=<epoch>)`.

---

### Runs offline
No new runtime network dependencies. Earth-orientation data comes from Astropy's
bundled table (no downloads, safely clamps out-of-range dates); the numerical
model uses SSAPy's bundled ephemeris/gravity data; the fits are plain
NumPy/SciPy. The drag model stays Harris-Priester, which needs no external
space-weather data.

### Documentation
- Cite the published JOSS paper (Meyers et al. 2025, JOSS 10(111), 8147,
  doi:10.21105/joss.08147) as the primary citation, with BibTeX, and point the
  JOSS badge at the DOI.
- Add a dedicated **SSAPy-Toolkit** section describing the companion project.
- Fix a broken link in the README (it pointed at a bib file that doesn't exist).

### Testing
- New: `tests/test_tle_drag.py` (8 tests — exact-SGP4 match, drag fit, joint
  orbit+drag fit) and `tests/test_frame_perstep.py` (3 tests — array support and
  accuracy vs Astropy).
- Existing `test_frame.py`, `test_orbit.py`, `test_io.py`: 27 pass, no
  regressions.
- `examples/tle_drag_paths.py` demonstrates all three features end to end.

### Possible follow-ups (not in this PR)
- Faster/more-robust Jacobian for the orbit-determination fit (currently
  finite-difference).
- Optional higher-fidelity atmosphere model (NRLMSISE-00 / JB2008) as a drop-in
  drag option — deferred to keep SSAPy fully offline for now.