### PR TITLE
Handle the Harris-Priester upper altitude boundary safely

### DIFF
--- a/src/ssapy.cpp
+++ b/src/ssapy.cpp
@@ -68,10 +68,20 @@ namespace ssapy {
             _n/2
         );
 
-        auto hptr = std::upper_bound(_h.cbegin(), _h.cend(), height);
-        auto idx = std::distance(_h.cbegin(), hptr);
-        double rho_antapex = _rho_antapex[idx-1] * exp(-(height-_h[idx-1])/_scale_antapex[idx-1]);  // MG (3.101)
-        double rho_apex = _rho_apex[idx-1] * exp(-(height-_h[idx-1])/_scale_apex[idx-1]);
+        double rho_antapex;
+        double rho_apex;
+        if (height == _h.back()) {
+            // The scale-height arrays describe the 49 intervals between the
+            // 50 tabulated altitudes. At the upper table boundary there is no
+            // following interval, so use the tabulated endpoint directly.
+            rho_antapex = _rho_antapex.back();
+            rho_apex = _rho_apex.back();
+        } else {
+            auto hptr = std::upper_bound(_h.cbegin(), _h.cend(), height);
+            auto idx = std::distance(_h.cbegin(), hptr);
+            rho_antapex = _rho_antapex[idx-1] * exp(-(height-_h[idx-1])/_scale_antapex[idx-1]);  // MG (3.101)
+            rho_apex = _rho_apex[idx-1] * exp(-(height-_h[idx-1])/_scale_apex[idx-1]);
+        }
         return (rho_antapex + (rho_apex - rho_antapex)*cosnpsi2) * 1e-12;
     }
 

--- a/tests/test_harris_priester_bounds.py
+++ b/tests/test_harris_priester_bounds.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from ssapy.accel import AccelDrag
+from ssapy.constants import EARTH_RADIUS
+
+
+def test_harris_priester_upper_table_boundary_uses_endpoint_density():
+    atmosphere = AccelDrag().atm
+    radius = EARTH_RADIUS + 1_000_000.0
+
+    density = atmosphere.density(radius, 0.0, 0.0, 0.0, 0.0)
+
+    assert np.isfinite(density)
+    assert 1.150e-15 <= density <= 1.810e-14
+
+
+def test_harris_priester_above_upper_table_boundary_is_zero():
+    atmosphere = AccelDrag().atm
+    radius = EARTH_RADIUS + 1_000_001.0
+
+    density = atmosphere.density(radius, 0.0, 0.0, 0.0, 0.0)
+
+    assert density == 0.0


### PR DESCRIPTION
## Summary

Handle the 1000 km upper boundary of the Harris-Priester density table without indexing beyond the scale-height arrays.

## Problem

The implementation has 50 tabulated density altitudes but 49 scale heights, one for each interval. At exactly the final tabulated altitude, 1000 km, `std::upper_bound` returns the end iterator, producing `idx == 50`; the interpolation path then reads scale-height element 49 outside the 49-element arrays.

The 1000 km point is itself tabulated, so it should use the final apex and antapex densities directly. Altitudes above 1000 km retain the existing zero-density behavior.

## Change

- Use the tabulated endpoint densities at exactly the upper model boundary.
- Keep interval interpolation unchanged below 1000 km.
- Keep density equal to zero above the table domain.
- Add regression tests for the boundary and immediately above it.

## Testing

Full SSAPy CI passes on the branch: Ubuntu/Python 3.10 and 3.12 pytest runs, macOS build/import checks, and documentation build.