### PR TITLE
Use float64 buffers for ellipsoid coordinate transforms

### DIFF
--- a/ssapy/ellipsoid.py
+++ b/ssapy/ellipsoid.py
@@ -9,7 +9,7 @@ parameter f, but that's good enough for simple Earth models.
 import numpy as np
 from .utils import continueClass
 from . import _ssapy
-from ._ssapy import Ellipsoid   
+from ._ssapy import Ellipsoid
 
 
 @continueClass
@@ -21,11 +21,11 @@ class Ellipsoid:
     -------
     sphereToCart(lon, lat, height)
         Converts spherical coordinates (longitude, latitude, height) to Cartesian coordinates (x, y, z).
-    
+
     cartToSphere(x, y, z)
         Converts Cartesian coordinates (x, y, z) to spherical coordinates (longitude, latitude, height).
     """
-    
+
     def sphereToCart(self, lon, lat, height):
         """
         Converts spherical coordinates to Cartesian coordinates.
@@ -52,14 +52,14 @@ class Ellipsoid:
 
         Notes
         -----
-        This method uses broadcasting to handle inputs of varying shapes and ensures 
+        This method uses broadcasting to handle inputs of varying shapes and ensures
         contiguous arrays for efficient computation.
         """
 
         lon, lat, height = np.broadcast_arrays(lon, lat, height)
-        lon = np.ascontiguousarray(lon)
-        lat = np.ascontiguousarray(lat)
-        height = np.ascontiguousarray(height)
+        lon = np.ascontiguousarray(lon, dtype=np.float64)
+        lat = np.ascontiguousarray(lat, dtype=np.float64)
+        height = np.ascontiguousarray(height, dtype=np.float64)
 
         x = np.empty_like(lon)
         y = np.empty_like(lon)
@@ -98,14 +98,14 @@ class Ellipsoid:
 
         Notes
         -----
-        This method uses broadcasting to handle inputs of varying shapes and ensures 
+        This method uses broadcasting to handle inputs of varying shapes and ensures
         contiguous arrays for efficient computation.
         """
 
         x, y, z = np.broadcast_arrays(x, y, z)
-        x = np.ascontiguousarray(x)
-        y = np.ascontiguousarray(y)
-        z = np.ascontiguousarray(z)
+        x = np.ascontiguousarray(x, dtype=np.float64)
+        y = np.ascontiguousarray(y, dtype=np.float64)
+        z = np.ascontiguousarray(z, dtype=np.float64)
 
         lon = np.empty_like(x)
         lat = np.empty_like(x)
@@ -117,6 +117,3 @@ class Ellipsoid:
         )
 
         return lon, lat, height
-
-
-

--- a/tests/test_ellipsoid_dtypes.py
+++ b/tests/test_ellipsoid_dtypes.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from ssapy.ellipsoid import Ellipsoid
+
+
+def test_sphere_to_cart_coerces_integer_inputs_to_float64():
+    ellipsoid = Ellipsoid(Req=6378137.0, f=1 / 298.257223563)
+    lon = np.array([0, 0], dtype=np.int64)
+    lat = np.array([0, 0], dtype=np.int64)
+    height = np.array([0, 1000], dtype=np.int64)
+
+    x, y, z = ellipsoid.sphereToCart(lon, lat, height)
+
+    assert x.dtype == np.float64
+    assert y.dtype == np.float64
+    assert z.dtype == np.float64
+    np.testing.assert_allclose(x, [6378137.0, 6379137.0], atol=1e-9)
+    np.testing.assert_allclose(y, [0.0, 0.0], atol=1e-12)
+    np.testing.assert_allclose(z, [0.0, 0.0], atol=1e-12)
+
+
+def test_cart_to_sphere_coerces_integer_inputs_to_float64():
+    ellipsoid = Ellipsoid(Req=6378137.0, f=1 / 298.257223563)
+    x = np.array([6378137, 6379137], dtype=np.int64)
+    y = np.array([0, 0], dtype=np.int64)
+    z = np.array([0, 0], dtype=np.int64)
+
+    lon, lat, height = ellipsoid.cartToSphere(x, y, z)
+
+    assert lon.dtype == np.float64
+    assert lat.dtype == np.float64
+    assert height.dtype == np.float64
+    np.testing.assert_allclose(lon, [0.0, 0.0], atol=1e-12)
+    np.testing.assert_allclose(lat, [0.0, 0.0], atol=1e-12)
+    np.testing.assert_allclose(height, [0.0, 1000.0], atol=1e-6)


### PR DESCRIPTION
## Summary

Ensure the Python ellipsoid wrappers always pass C-contiguous `float64` buffers to the native coordinate-transform routines.

## Problem

`sphereToCart()` and `cartToSphere()` currently preserve the NumPy dtype of their inputs. The native SSAPy routines consume raw pointers as C++ `double` arrays, so integer or `float32` inputs can be interpreted with the wrong element representation. Output arrays created with `empty_like()` inherit the same incompatible dtype.

## Change

- Convert broadcast inputs to contiguous `np.float64` arrays before passing their pointers to the native routines.
- Keep outputs in `float64`, matching the native `double` API.
- Add reference tests using integer coordinate arrays in both conversion directions.

## Testing

Full SSAPy CI passes on the branch: Ubuntu/Python 3.10 and 3.12 pytest runs, macOS build/import checks, and documentation build.