### PR TITLE
Use gravity-model reference radius for harmonic acceleration

### DIFF
--- a/ssapy/gravity.py
+++ b/ssapy/gravity.py
@@ -298,7 +298,7 @@ class AccelHarmonic(_Accel):
             self.m_max = m_max
         self._harmonic = _ssapy.AccelHarmonic(
             self.body.mu,
-            self.body.radius,
+            self.body.harmonics.radius,
             self.body.harmonics.CS.shape[0],
             self.body.harmonics.CS.ctypes.data
         )

--- a/tests/test_gravity_reference_radius.py
+++ b/tests/test_gravity_reference_radius.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+import ssapy.gravity as gravity
+
+
+def test_accel_harmonic_uses_coefficient_reference_radius(monkeypatch):
+    captured = {}
+
+    class FakeAccelHarmonic:
+        def __init__(self, mu, radius, ncol, cs_ptr):
+            captured['mu'] = mu
+            captured['radius'] = radius
+            captured['ncol'] = ncol
+            captured['cs_ptr'] = cs_ptr
+
+    monkeypatch.setattr(gravity._ssapy, 'AccelHarmonic', FakeAccelHarmonic)
+
+    coefficients = SimpleNamespace(
+        name='test-gravity-model',
+        radius=1_738_000.0,
+        n_max=2,
+        m_max=2,
+        CS=np.zeros((3, 3), dtype=float),
+    )
+    body = SimpleNamespace(
+        mu=4.9048695e12,
+        radius=1_737_400.0,
+        harmonics=coefficients,
+    )
+
+    gravity.AccelHarmonic(body)
+
+    assert captured['mu'] == body.mu
+    assert captured['radius'] == coefficients.radius
+    assert captured['radius'] != body.radius
+    assert captured['ncol'] == coefficients.CS.shape[0]


### PR DESCRIPTION
## Summary

Use the spherical-harmonic coefficient set's reference radius when constructing the native `AccelHarmonic` evaluator.

## Problem

`HarmonicCoefficients.fromEGM()` and `fromTAB()` both read and retain the reference radius associated with the coefficient model, but `AccelHarmonic` currently passes `body.radius` to the native harmonic evaluator instead.

The reference radius is part of the definition of a spherical-harmonic gravity model. Using a different physical/body radius changes the radial scaling of non-central terms. The distinction is especially relevant for lunar models, where the body's nominal radius and the gravity model's reference radius need not be identical.

## Change

- Pass `body.harmonics.radius` to `_ssapy.AccelHarmonic`.
- Add a regression test with deliberately different body and coefficient reference radii to ensure the model radius is selected.

## Testing

Full SSAPy CI passes on the branch: Ubuntu/Python 3.10 and 3.12 pytest runs, macOS build/import checks, and documentation build.