### PR TITLE
Invalidate particle caches after particle-state mutations

### DIFF
--- a/ssapy/particles.py
+++ b/ssapy/particles.py
@@ -105,6 +105,8 @@ class Particles:
     def reset_to_pseudo_prior(self):
         self.particles = self.initial_particles.copy()
         self.ln_wts = self.initial_ln_wts.copy()
+        self._orbits = None
+        self._lnpriors = None
 
     @property
     def epoch(self):
@@ -192,6 +194,8 @@ class Particles:
         # Append particles and weights in anticipation of resampling / downsampling
         self.particles = np.vstack((self.particles, epoch_particles.move(self.epoch)))
         self.ln_wts = np.append(ln_wts, epoch_ln_wts)
+        self._orbits = None
+        self._lnpriors = None
 
         if np.logaddexp.reduce(self.ln_wts) < -100.:
             status = False

--- a/tests/test_particles_cache_invalidation.py
+++ b/tests/test_particles_cache_invalidation.py
@@ -1,0 +1,56 @@
+import numpy as np
+
+from ssapy.particles import Particles
+
+
+class DummyProbability:
+    epoch = 0.0
+
+    def lnprior(self, orbit):
+        return orbit.r[0] * 1e-6
+
+    def lnlike(self, orbit):
+        return -0.5
+
+
+def make_particles(offset=0.0):
+    samples = np.array([
+        [7.0e6, 0.0, 0.0, 0.0, 7.5e3, 0.0],
+        [7.1e6, 0.0, 0.0, 0.0, 7.4e3, 0.0],
+    ]) + offset
+    return Particles(samples, DummyProbability(), ln_weights=np.zeros(2))
+
+
+def test_reset_to_pseudo_prior_invalidates_derived_caches():
+    population = make_particles()
+    initial = population.initial_particles.copy()
+
+    population.particles = population.particles + 1.0e5
+    population._orbits = None
+    population._lnpriors = None
+    assert population.orbits[0].r[0] != initial[0, 0]
+    _ = population.lnpriors
+
+    population.reset_to_pseudo_prior()
+
+    np.testing.assert_allclose(population.orbits[0].r, initial[0, :3])
+    assert len(population.lnpriors) == len(initial)
+    assert population.lnpriors[0] == population.rvprobability.lnprior(population.orbits[0])
+
+
+def test_reweight_invalidates_caches_after_appending_particles():
+    population = make_particles()
+    other = make_particles(offset=1000.0)
+
+    # Populate both derived caches before reweight changes the particle array.
+    assert len(population.orbits) == 2
+    assert len(population.lnpriors) == 2
+
+    # Avoid testing propagation here; this regression is about cache lifetime.
+    other.move = lambda epoch: other.particles.copy()
+    population.reweight(other)
+
+    assert population.particles.shape[0] == 4
+    assert len(population.orbits) == 4
+    assert len(population.lnpriors) == 4
+    np.testing.assert_allclose(population.orbits[-1].r, other.particles[-1, :3])


### PR DESCRIPTION
## Summary

Invalidate cached `Orbit` objects and cached log priors whenever the underlying particle population is replaced or extended.

## Problem

`Particles.orbits` and `Particles.lnpriors` are lazy caches derived from `self.particles`. `reset_to_pseudo_prior()` replaces the particle array without clearing either cache, and `reweight()` appends particles without clearing them. If either cache was accessed before those operations, subsequent inference can use orbit states or prior values from the old population.

## Change

- Clear `_orbits` and `_lnpriors` after resetting to the pseudo-prior.
- Clear both caches after `reweight()` appends the cross-epoch particle population.
- Add regression tests proving that cached orbit/prior lengths and values follow the new particle state after both operations.

## Testing

Full SSAPy CI passes on the branch, including Ubuntu/Python 3.10 and 3.12 pytest runs, both macOS build/import jobs, and the documentation build.