### PR TITLE
Honor requested particle count when resampling

### DIFF
--- a/ssapy/particles.py
+++ b/ssapy/particles.py
@@ -220,14 +220,14 @@ class Particles:
         # Reset the stored orbits array
         self._orbits = None
 
-        # Down-sample (without replacement) from the current particle list if
-        # the requested number of particles does not match the current number.
-        if self.particles.shape[0] > self.num_particles:
-            ndx = np.random.choice(self.particles.shape[0], size=num_particles, replace=False)
+        available = self.particles.shape[0]
+        if num_particles > available:
+            raise ValueError("Requested more particles than we have")
+        if num_particles < available:
+            ndx = np.random.choice(available, size=num_particles, replace=False)
             self.particles = self.particles[ndx, ]
             self.ln_wts = self.ln_wts[ndx]
-        elif self.num_particles > self.particles.shape[0]:
-            raise ValueError("Requested more particles than we have")
+        self.num_particles = self.particles.shape[0]
         return None
 
     def fuse(self, epoch_particles, verbose=False):

--- a/tests/test_particles_resample_count.py
+++ b/tests/test_particles_resample_count.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+
+import ssapy.particles as particles_module
+from ssapy.particles import Particles
+
+
+class DummyProbability:
+    epoch = 0.0
+
+    def lnprior(self, orbit):
+        return 0.0
+
+
+def make_particles(n=5):
+    samples = np.arange(n * 6, dtype=float).reshape(n, 6)
+    return Particles(
+        samples,
+        DummyProbability(),
+        lnpriors=np.zeros(n),
+        ln_weights=np.zeros(n),
+    )
+
+
+def identity_resample(particles, ln_wts, pod=True):
+    return particles.copy(), np.full(len(particles), 1.0 / len(particles))
+
+
+def test_resample_honors_requested_particle_count(monkeypatch):
+    population = make_particles(5)
+    monkeypatch.setattr(particles_module.utils, 'resample', identity_resample)
+    monkeypatch.setattr(
+        np.random,
+        'choice',
+        lambda n, size, replace: np.arange(size),
+    )
+
+    population.resample(3)
+
+    assert population.particles.shape == (3, 6)
+    assert population.ln_wts.shape == (3,)
+    assert population.num_particles == 3
+
+
+def test_resample_rejects_more_particles_than_available(monkeypatch):
+    population = make_particles(5)
+    monkeypatch.setattr(particles_module.utils, 'resample', identity_resample)
+
+    with pytest.raises(ValueError, match='Requested more particles than we have'):
+        population.resample(6)


### PR DESCRIPTION
## Summary

Make `Particles.resample(num_particles)` honor its `num_particles` argument and keep `num_particles` synchronized with the resulting particle population.

## Problem

The method currently decides whether to downsample by comparing the resampled population size with the object's old `self.num_particles`, rather than the requested output count. A direct call such as `resample(3)` on a five-particle population can therefore retain all five particles. The inverse size check has the same issue, and the stored count is not updated after a successful size change.

## Change

- Compare the requested count against the post-resampling population size.
- Reject requests larger than the available population.
- Downsample whenever the requested count is smaller.
- Update `self.num_particles` to match the resulting population.
- Add deterministic regression tests for downsampling and invalid oversized requests.

## Testing

Full SSAPy CI passes on the branch, including Ubuntu/Python 3.10 and 3.12 pytest runs, both macOS build/import jobs, and the documentation build.