### PR TITLE
Apply cylindrical Earth shadow to solar radiation pressure

### DIFF
--- a/ssapy/accel.py
+++ b/ssapy/accel.py
@@ -224,7 +224,21 @@ class AccelSolRad(Accel):
         kw = dict()
         kw.update(self.defaultkw)
         kw.update(kwargs)
-        rr = r - sunPos(t)
+        r = np.asarray(r, dtype=float)
+        r_sun = sunPos(t)
+
+        # Cylindrical Earth-shadow approximation from the model description:
+        # an object is eclipsed when it is behind Earth relative to the Sun and
+        # its perpendicular distance from the Sun-Earth axis is within Earth's
+        # radius.
+        sun_hat = r_sun / norm(r_sun)
+        axial = np.dot(r, sun_hat)
+        if axial < 0:
+            cross_axis = r - axial * sun_hat
+            if norm(cross_axis) <= EARTH_RADIUS:
+                return np.zeros_like(r)
+
+        rr = r - r_sun
         P0 = 4.56e-6  # Solar rad pressure [N/m^2]   MG eqn (3.69)
         AU2 = 2.2379522708536898e22  # 1 AU squared [m^2]
         # MG (3.75)

--- a/tests/test_solar_radiation_shadow.py
+++ b/tests/test_solar_radiation_shadow.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+import ssapy.accel as accel
+from ssapy.constants import EARTH_RADIUS
+
+
+def test_solar_radiation_pressure_is_zero_in_cylindrical_earth_shadow(monkeypatch):
+    sun_position = np.array([1.5e11, 0.0, 0.0])
+    monkeypatch.setattr(accel, 'sunPos', lambda t: sun_position)
+
+    model = accel.AccelSolRad(area=2.0, mass=100.0, CR=1.3)
+
+    shadowed = np.array([-7.0e6, 0.0, 0.0])
+    outside_shadow = np.array([-7.0e6, EARTH_RADIUS + 1.0e3, 0.0])
+    sunward = np.array([7.0e6, 0.0, 0.0])
+
+    np.testing.assert_array_equal(model(shadowed, None, 0.0), np.zeros(3))
+    assert np.linalg.norm(model(outside_shadow, None, 0.0)) > 0.0
+    assert np.linalg.norm(model(sunward, None, 0.0)) > 0.0
+
+
+def test_solar_radiation_shadow_boundary_uses_earth_radius(monkeypatch):
+    sun_position = np.array([1.5e11, 0.0, 0.0])
+    monkeypatch.setattr(accel, 'sunPos', lambda t: sun_position)
+
+    model = accel.AccelSolRad(area=1.0, mass=10.0, CR=1.0)
+    on_cylinder = np.array([-1.0e7, EARTH_RADIUS, 0.0])
+    just_outside = np.array([-1.0e7, EARTH_RADIUS + 1.0, 0.0])
+
+    np.testing.assert_array_equal(model(on_cylinder, None, 0.0), np.zeros(3))
+    assert np.linalg.norm(model(just_outside, None, 0.0)) > 0.0


### PR DESCRIPTION
## Summary

Make `AccelSolRad` implement the cylindrical Earth-shadow model already documented by the class.

## Problem

The model states that solar-radiation pressure is zero when a spacecraft is inside Earth's cylindrical shadow, but `__call__` always applies full solar pressure. This introduces a nonphysical force during eclipse intervals and can bias propagated trajectories, especially for high area-to-mass objects.

## Change

- Determine whether the spacecraft is behind Earth relative to the Sun.
- Compute its perpendicular distance from the Sun-Earth axis.
- Return zero solar-radiation acceleration inside the Earth-radius cylinder.
- Leave the existing illuminated-spacecraft pressure calculation unchanged.
- Add regression tests for shadowed, sunward, outside-cylinder, and exact-boundary cases.

## Testing

Full SSAPy CI passes on the branch, including Ubuntu/Python 3.10 and 3.12 pytest runs, both macOS build/import jobs, and the documentation build.