### PR TITLE
Cap TAB gravity-model order at the truncated degree

### DIFF
--- a/ssapy/gravity.py
+++ b/ssapy/gravity.py
@@ -154,7 +154,7 @@ class HarmonicCoefficients:
                 lat_ref_deg
             ) = np.array(f.readline().replace(',', ' ').split()).astype(float)
         n_max = min(int(n_max1), n_max)
-        m_max = min(int(m_max1), m_max)
+        m_max = min(int(m_max1), m_max, n_max)
 
         # read array (TODO: only read relevant rows)
         max_rows = (n_max + 2) * (n_max + 1) // 2 + 2

--- a/tests/test_gravity_tab_order.py
+++ b/tests/test_gravity_tab_order.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+import ssapy.gravity as gravity
+
+
+def test_from_tab_caps_order_at_truncated_degree(tmp_path, monkeypatch):
+    model = tmp_path / 'test.tab'
+    model.write_text(
+        '1738.0,4902.8,0.0,2,2,1,0,0\n'
+        '0,0,1,0,0,0\n'
+        '1,0,0,0,0,0\n'
+        '1,1,0,0,0,0\n'
+        '2,0,0,0,0,0\n'
+        '2,1,0,0,0,0\n'
+        '2,2,0,0,0,0\n'
+    )
+    monkeypatch.setattr(
+        gravity,
+        'find_file',
+        lambda filename, ext=None: str(model),
+    )
+
+    coefficients = gravity.HarmonicCoefficients.fromTAB(
+        'test', n_max=1, m_max=2
+    )
+
+    assert coefficients.n_max == 1
+    assert coefficients.m_max == 1
+    assert coefficients.m_max <= coefficients.n_max
+    assert coefficients.CS.shape == (2, 2)
+    assert np.isfinite(coefficients.CS[1, 1])


### PR DESCRIPTION
## Summary

Keep spherical-harmonic order consistent with the truncated degree when loading `.tab` gravity models.

## Problem

`HarmonicCoefficients.fromTAB()` truncates `n_max` and `m_max` independently. A request with a lower degree than order can therefore produce `m_max > n_max`, inconsistent with spherical-harmonic mathematics and the dimensions of the truncated coefficient matrix.

## Change

- Cap `m_max` at the effective `n_max`.
- Add a synthetic TAB regression test verifying consistent metadata and matrix dimensions.

## Testing

Full SSAPy CI passes on Ubuntu/Python 3.10 and 3.12 and macOS/Python 3.10 and 3.12, including the documentation build.