### PR TITLE
Return vector zero acceleration when NTW burn is inactive

### DIFF
--- a/ssapy/accel.py
+++ b/ssapy/accel.py
@@ -462,7 +462,7 @@ class AccelConstNTW(Accel):
         ind = np.searchsorted(self.time_breakpoints, t)
         off = (ind % 2) == 0
         if off:
-            return 0
+            return np.zeros(3)
         else:
             return ntw_to_r(r, v, self.accelntw, relative=True)
 

--- a/tests/test_const_ntw_off_vector.py
+++ b/tests/test_const_ntw_off_vector.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from ssapy.accel import AccelConstNTW, AccelKepler
+
+
+def test_inactive_const_ntw_returns_zero_vector():
+    burn = AccelConstNTW([0.0, 1e-5, 0.0], time_breakpoints=[10.0, 20.0])
+    out = burn(np.array([7000e3, 0.0, 0.0]),
+               np.array([0.0, 7500.0, 0.0]),
+               0.0)
+
+    assert out.shape == (3,)
+    np.testing.assert_array_equal(out, np.zeros(3))
+
+
+def test_inactive_const_ntw_can_be_first_term_in_acceleration_sum():
+    burn = AccelConstNTW([0.0, 1e-5, 0.0], time_breakpoints=[10.0, 20.0])
+    kepler = AccelKepler()
+    combined = burn + kepler
+
+    r = np.array([7000e3, 0.0, 0.0])
+    v = np.array([0.0, 7500.0, 0.0])
+
+    expected = kepler(r, v, 0.0)
+    actual = combined(r, v, 0.0)
+
+    np.testing.assert_allclose(actual, expected)


### PR DESCRIPTION
## Summary

Return a three-component zero acceleration from `AccelConstNTW` while a scheduled burn is inactive.

## Problem

The active path returns a Cartesian acceleration vector, but the inactive path returns scalar `0`. This violates the acceleration interface and can break `AccelSum` when an inactive NTW burn is the first term.

## Change

- Return `np.zeros(3)` for the inactive burn state.
- Add regression tests for the inactive result and composition with Keplerian gravity.

## Testing

Full SSAPy CI passes on Ubuntu/Python 3.10 and 3.12 and macOS/Python 3.10 and 3.12, including the documentation build.