### PR TITLE
Normalize linker model probabilities in log space

### DIFF
--- a/ssapy/linker.py
+++ b/ssapy/linker.py
@@ -192,7 +192,9 @@ class Linker(object):
         if np.all(lnL < -500.):  # Likelihoods are all small - reset to equal linking probabilities
             prob_k = np.ones(n) * 0.5
         else:
-            prob_k = np.exp(lnL + np.log(self.p_orbit[track_ndx]))
+            log_prob_k = lnL + np.log(self.p_orbit[track_ndx])
+            log_prob_k -= np.max(log_prob_k)
+            prob_k = np.exp(log_prob_k)
         prob_k /= np.sum(prob_k)
         if verbose:
             print("prob_k:", prob_k)

--- a/tests/test_linker_log_probabilities.py
+++ b/tests/test_linker_log_probabilities.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from ssapy.linker import Linker
+
+
+class FakeIOD:
+    def __init__(self, model_id, likelihoods):
+        self.model_id = model_id
+        self._likelihoods = likelihoods
+
+    def draw_orbit(self):
+        return self.model_id
+
+    def lnlike(self, model_id):
+        return self._likelihoods[model_id]
+
+
+def test_selector_probabilities_remain_finite_with_tiny_priors(monkeypatch):
+    likelihoods = np.array([-400.0, -401.0, -2000.0])
+    linker = Linker([
+        FakeIOD(0, likelihoods),
+        FakeIOD(1, likelihoods),
+        FakeIOD(2, likelihoods),
+    ])
+    linker.p_orbit[2] = np.array([1e-320, 2e-320, 1.0])
+
+    captured = {}
+
+    def fake_multinomial(n, pvals):
+        captured['pvals'] = pvals.copy()
+        return np.array([1, 0, 0])
+
+    monkeypatch.setattr(np.random, 'multinomial', fake_multinomial)
+
+    linker.sample_orbit_selectors_from_data_conditional(2, verbose=False)
+    pvals = captured['pvals']
+
+    assert np.all(np.isfinite(pvals))
+    assert np.isclose(np.sum(pvals), 1.0)
+    assert pvals[0] > 0.0
+    assert pvals[1] > 0.0
+    assert pvals[2] < pvals[0]


### PR DESCRIPTION
## Summary

Normalize orbit-model selector probabilities in log space before drawing the multinomial assignment.

## Problem

`sample_orbit_selectors_from_data_conditional()` exponentiates log likelihood plus log prior directly. With very small but valid model probabilities, all unnormalized weights can underflow to zero even though their relative probabilities are well defined, producing NaNs during normalization.

## Change

- Form log posterior model weights first.
- Subtract the maximum before exponentiation.
- Preserve the existing all-small-likelihood fallback.
- Add a regression test for tiny nonzero model priors.

## Testing

Full SSAPy CI passes on Ubuntu/Python 3.10 and 3.12 and macOS/Python 3.10 and 3.12, including the documentation build.