### PR TITLE
Stabilize weighted particle mean for extreme log weights

### DIFF
--- a/ssapy/particles.py
+++ b/ssapy/particles.py
@@ -277,4 +277,5 @@ class Particles:
         mean : (6,) array_like
             Weighted mean of the particle values (3*m, 3*m/s)
         """
-        return np.average(self.particles, axis=0, weights=np.exp(self.ln_wts))
+        weights = utils.get_normed_weights(self.ln_wts)
+        return np.average(self.particles, axis=0, weights=weights)

--- a/tests/test_particles_mean_logweights.py
+++ b/tests/test_particles_mean_logweights.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from ssapy.particles import Particles
+
+
+def test_mean_is_stable_for_large_negative_log_weights():
+    particles = np.array([
+        [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        [11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
+    ])
+    log_weights = np.array([-1000.0, -1001.0])
+    rvprobability = SimpleNamespace(epoch=0.0)
+
+    sample = Particles(
+        particles,
+        rvprobability,
+        ln_weights=log_weights,
+    )
+
+    shifted = log_weights - np.max(log_weights)
+    weights = np.exp(shifted) / np.sum(np.exp(shifted))
+    expected = np.average(particles, axis=0, weights=weights)
+
+    result = sample.mean()
+
+    assert np.all(np.isfinite(result))
+    np.testing.assert_allclose(result, expected)


### PR DESCRIPTION
## Summary

Compute `Particles.mean()` using normalized log weights rather than exponentiating raw log weights directly.

## Problem

Valid posterior log weights such as `[-1000, -1001]` underflow to zero when exponentiated directly, so `np.average` can receive a zero total weight and return a non-finite mean.

## Change

- Normalize log weights with the existing `utils.get_normed_weights()` helper.
- Add a regression test with extreme negative log weights against a shifted-softmax reference.

## Testing

Full SSAPy CI passes on Ubuntu/Python 3.10 and 3.12 and macOS/Python 3.10 and 3.12, including the documentation build.