### PR TITLE
Cap harmonic acceleration order at selected degree

### DIFF
--- a/ssapy/gravity.py
+++ b/ssapy/gravity.py
@@ -296,6 +296,12 @@ class AccelHarmonic(_Accel):
             self.m_max = body.harmonics.m_max
         else:
             self.m_max = m_max
+        if self.m_max > self.n_max:
+            print(
+                f"WARNING::The provided order ({self.m_max}) is higher than the selected degree "
+                f"({self.n_max}).\nSetting the order to {self.n_max}."
+            )
+            self.m_max = self.n_max
         self._harmonic = _ssapy.AccelHarmonic(
             self.body.mu,
             self.body.radius,

--- a/tests/test_harmonic_order_degree_cap.py
+++ b/tests/test_harmonic_order_degree_cap.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+import ssapy.gravity as gravity
+
+
+def test_harmonic_order_is_capped_at_selected_degree(monkeypatch):
+    captured = {}
+
+    class NativeHarmonic:
+        def __init__(self, mu, radius, size, ptr):
+            captured["init"] = (mu, radius, size, ptr)
+
+    monkeypatch.setattr(gravity._ssapy, "AccelHarmonic", NativeHarmonic)
+
+    harmonics = SimpleNamespace(
+        n_max=8,
+        m_max=8,
+        name="synthetic",
+        CS=np.zeros((9, 9), dtype=float),
+    )
+    body = SimpleNamespace(mu=1.0, radius=2.0, harmonics=harmonics)
+
+    accel = gravity.AccelHarmonic(body, n_max=3, m_max=7)
+
+    assert accel.n_max == 3
+    assert accel.m_max == 3
+    assert captured["init"][2] == 9


### PR DESCRIPTION
## Summary

Enforce the spherical-harmonic invariant that the selected order cannot exceed the selected degree in `AccelHarmonic`.

## Problem

`AccelHarmonic(body, n_max=..., m_max=...)` caps degree and order only against the source-model limits. A caller can therefore select, for example, degree 3 and order 7. Spherical-harmonic terms require `m <= n`, so this is an inconsistent truncation passed to the native gravity evaluator.

## Change

- Cap the effective `m_max` at the effective `n_max` after model-limit handling.
- Preserve the existing warning style.
- Add a focused regression test using a synthetic harmonic model and native evaluator stub.

## Testing

Full SSAPy CI passes on Ubuntu/Python 3.10 and 3.12 and macOS/Python 3.10 and 3.12, including the documentation build.