### PR TITLE
Preserve custom gravitational parameter when selecting vector orbits

### DIFF
--- a/ssapy/orbit.py
+++ b/ssapy/orbit.py
@@ -700,6 +700,7 @@ class Orbit:
                 self.r[self._iter],
                 self.v[self._iter],
                 self.t[self._iter],
+                mu=self.mu,
                 propkw={k: v[self._iter] for k, v in self.propkw.items()}
             )
             if kMKE is not None:
@@ -722,7 +723,7 @@ class Orbit:
             kMKE = self.__dict__['kozaiMeanKeplerianElements']
         else:
             kMKE = None
-        out = Orbit(self.r[idx], self.v[idx], self.t[idx],
+        out = Orbit(self.r[idx], self.v[idx], self.t[idx], mu=self.mu,
                     propkw={k: v[idx] for k, v in self.propkw.items()})
         if kMKE is not None:
             out.kozaiMeanKeplerianElements = kMKE

--- a/tests/test_orbit_custom_mu_selection.py
+++ b/tests/test_orbit_custom_mu_selection.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from ssapy.orbit import Orbit
+
+
+def _custom_mu_vector_orbit():
+    mu = 4.9048695e12
+    radii = np.array([1.8e6, 2.0e6])
+    r = np.column_stack((radii, np.zeros(2), np.zeros(2)))
+    v = np.column_stack((np.zeros(2), np.sqrt(mu / radii), np.zeros(2)))
+    orbit = Orbit(r, v, np.array([0.0, 10.0]), mu=mu)
+    return orbit, mu, radii
+
+
+def test_vector_orbit_index_preserves_custom_mu():
+    orbit, mu, radii = _custom_mu_vector_orbit()
+
+    selected = orbit[0]
+
+    assert selected.mu == mu
+    np.testing.assert_allclose(selected.a, radii[0], rtol=1e-12)
+
+
+def test_vector_orbit_iteration_preserves_custom_mu():
+    orbit, mu, radii = _custom_mu_vector_orbit()
+
+    selected = list(orbit)
+
+    assert all(item.mu == mu for item in selected)
+    np.testing.assert_allclose([item.a for item in selected], radii, rtol=1e-12)


### PR DESCRIPTION
## Summary

Preserve a vector `Orbit` object's central-body gravitational parameter when selecting or iterating over scalar component orbits.

## Problem

`Orbit.__getitem__()` and `Orbit.__next__()` construct new scalar `Orbit` objects without passing `self.mu`, so they silently fall back to Earth's gravitational parameter. A vector orbit created for the Moon or another non-Earth central body therefore changes its dynamics when indexed or iterated.

## Change

- Pass `mu=self.mu` when constructing scalar orbits from indexing and iteration.
- Add lunar-scale regression cases checking both retained `mu` and the resulting circular-orbit semimajor axes.

## Testing

Full SSAPy CI passes on Ubuntu/Python 3.10 and 3.12 and macOS/Python 3.10 and 3.12, including the documentation build.