### PR TITLE
Handle object-array Astropy times in track ordering

### DIFF
--- a/ssapy/correlate_tracks.py
+++ b/ssapy/correlate_tracks.py
@@ -1524,20 +1524,32 @@ def time_ordered_satIDs(data, with_time=False, order='forward'):
 
     list of corresponding gps times of first obs per ID
     """
-    s = np.argsort(data['time'].gps)
+    time_values = data['time']
+    if isinstance(time_values, Time):
+        times_gps = np.asarray(time_values.gps, dtype=float)
+    elif np.issubdtype(time_values.dtype, np.number):
+        times_gps = np.asarray(time_values, dtype=float)
+    else:
+        times_gps = np.asarray([
+            value.gps if isinstance(value, Time) else float(value)
+            for value in time_values
+        ], dtype=float)
+
+    s = np.argsort(times_gps)
     if order == 'backward':
         s = s[::-1]
     usedtracklet = {}
     out = []
     times = []
-    for satid in data['satID'][s]:
+    for idx in s:
+        satid = data['satID'][idx]
         if usedtracklet.get(satid, False):
             continue
         usedtracklet[satid] = True
         out.append(satid)
 
         if with_time:
-            times.append(data[data['satID'] == satid]['time'].gps[0])
+            times.append(times_gps[idx])
 
     res = out
     if with_time:

--- a/tests/test_issue_110_time_ordering.py
+++ b/tests/test_issue_110_time_ordering.py
@@ -1,0 +1,41 @@
+import numpy as np
+from astropy.time import Time
+
+from ssapy.correlate_tracks import time_ordered_satIDs
+
+
+def _object_time_data():
+    data = np.empty(5, dtype=[("satID", "i8"), ("time", object)])
+    data["satID"] = [2, 1, 2, 3, 1]
+    gps = np.array([30.0, 10.0, 20.0, 40.0, 15.0])
+    data["time"] = [Time(t, format="gps") for t in gps]
+    return data
+
+
+def test_time_ordered_satids_accepts_object_array_of_astropy_times():
+    data = _object_time_data()
+
+    satids, times = time_ordered_satIDs(data, with_time=True)
+
+    assert satids == [1, 2, 3]
+    np.testing.assert_allclose(times, [10.0, 20.0, 40.0])
+
+
+def test_time_ordered_satids_backward_uses_latest_observation_per_id():
+    data = _object_time_data()
+
+    satids, times = time_ordered_satIDs(data, with_time=True, order="backward")
+
+    assert satids == [3, 2, 1]
+    np.testing.assert_allclose(times, [40.0, 30.0, 15.0])
+
+
+def test_time_ordered_satids_accepts_numeric_gps_seconds():
+    data = np.empty(4, dtype=[("satID", "i8"), ("time", "f8")])
+    data["satID"] = [7, 8, 7, 9]
+    data["time"] = [3.0, 1.0, 2.0, 4.0]
+
+    satids, times = time_ordered_satIDs(data, with_time=True)
+
+    assert satids == [8, 7, 9]
+    np.testing.assert_allclose(times, [1.0, 2.0, 4.0])


### PR DESCRIPTION
## Summary

Handle structured-array `time` fields containing individual Astropy `Time` objects in `time_ordered_satIDs()`.

## Problem

When observations store scalar `Time` objects in an object-dtype NumPy field, `data['time']` is an ndarray rather than an Astropy `Time` vector. Accessing `data['time'].gps` therefore raises `AttributeError`, as reported in #110.

## Change

- Normalize Astropy `Time` vectors, object arrays of scalar `Time` values, and numeric GPS-second arrays to numeric GPS seconds.
- Sort using the normalized representation.
- Return the actual first observation time for each ID in forward order and latest observation time in backward order.
- Add regression tests for the reported object-array representation, reverse ordering, and numeric GPS seconds.

## Testing

Full SSAPy CI passes on Ubuntu/Python 3.10 and 3.12 and macOS/Python 3.10 and 3.12, including the documentation build.

Fixes #110