### PR TITLE
Avoid emcee sampler CI timeout

### DIFF
--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -719,6 +719,7 @@ def test_emcee_sampler_rejects_old_versions(monkeypatch):
         sampler.sample(nBurn=1, nStep=1)
 
 
+@pytest.mark.timeout(90)
 @timer
 def test_emcee_sampler():
     np.random.seed(57)


### PR DESCRIPTION
## Summary
- give the expensive emcee integration test a 90-second timeout
- preserve the 30-second default timeout for the rest of the suite
- leave sampler and scientific behavior unchanged

## Root cause
The Ubuntu/Python 3.10 worker completed its previous test at 06:39:15.127 and was terminated at 06:39:45.547, matching the global 30-second thread timeout. The test runs near that limit under xdist, so pytest-timeout exits the worker and xdist reports a worker crash.

## Validation
- Python 3.10 targeted xdist test: 1 passed
- Python 3.10 full CI-equivalent suite: 259 passed, 2 skipped
- pytest marker inspection confirms timeout(90) is attached
