### PR TITLE
Accept array-like time inputs in rv

### DIFF
--- a/ssapy/compute.py
+++ b/ssapy/compute.py
@@ -133,6 +133,8 @@ def _countTime(time):
         time = np.array([time])
         nTime = 1
         squeezeTime = True
+    else:
+        time = np.asarray(time)
     return nTime, squeezeTime, time
 
 

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -631,6 +631,24 @@ def test_rv():
     np.testing.assert_allclose(v, v2, rtol=0, atol=1e-2)
 
 
+def test_rv_accepts_list_and_tuple_times():
+    orbit = ssapy.Orbit(
+        np.array([7000e3, 0.0, 0.0]),
+        np.array([0.0, 7500.0, 0.0]),
+        0.0,
+    )
+    times = [0.0, 60.0, 120.0]
+
+    r_list, v_list = ssapy.rv(orbit, times)
+    r_tuple, v_tuple = ssapy.rv(orbit, tuple(times))
+    r_array, v_array = ssapy.rv(orbit, np.asarray(times))
+
+    np.testing.assert_allclose(r_list, r_array)
+    np.testing.assert_allclose(v_list, v_array)
+    np.testing.assert_allclose(r_tuple, r_array)
+    np.testing.assert_allclose(v_tuple, v_array)
+
+
 @timer
 # def test_groundTrack():
 #     np.random.seed(5772156)


### PR DESCRIPTION
## Summary

Accept normal Python list and tuple values for the documented `array_like` `time` argument in `ssapy.compute.rv()`.

## Problem

`_countTime()` leaves iterable inputs unchanged. `rv()` then passes them to `HashableArrayContainer`, which expects a NumPy array and accesses `.flags.writeable`. As a result, a Python list raises `AttributeError` before propagation.

## Change

- Convert non-scalar iterable time inputs to `np.asarray()` in `_countTime()`.
- Preserve the existing scalar squeezing behaviour.
- Add regression coverage showing list and tuple inputs match ndarray results.

## Validation

- `python3 -m compileall -q ssapy/compute.py tests/test_orbit.py`
- `git diff --check`

The local default Python environment does not have `pytest` installed, so the focused pytest case was not run locally.

Fixes #137
