### PR TITLE
Make Orbit propkw equality and hashing consistent

### DIFF
--- a/ssapy/orbit.py
+++ b/ssapy/orbit.py
@@ -744,33 +744,58 @@ class Orbit:
             out._propagation_propagator = self._propagation_propagator
         return out
 
+    @staticmethod
+    def _hashable_propkw_value(value):
+        array = np.asarray(value)
+        return array.shape, tuple(array.ravel().tolist())
+
     def __hash__(self):
         if not hasattr(self, '_hash'):
             self.r.flags.writeable = False
             self.v.flags.writeable = False
+            propkw = tuple(
+                (key, self._hashable_propkw_value(self.propkw[key]))
+                for key in sorted(self.propkw)
+            )
             if self.r.ndim == 1:
                 self._hash = hash((
                     self.r.data.tobytes(),
                     self.v.data.tobytes(),
                     self.t,
-                    self.mu) + tuple([(k, v.data.tobytes()) for k, v in self.propkw.items()])
-                )
+                    self.mu,
+                    propkw,
+                ))
             else:
                 self.t.flags.writeable = False
                 self._hash = hash((
                     self.r.data.tobytes(),
                     self.v.data.tobytes(),
                     self.t.data.tobytes(),
-                    self.mu) + tuple([(k, v.data.tobytes()) for k, v in self.propkw.items()])
-                )
+                    self.mu,
+                    propkw,
+                ))
         return self._hash
 
     def __eq__(self, rhs):
+        if not isinstance(rhs, Orbit):
+            return NotImplemented
         if self.r.ndim != rhs.r.ndim:
             return False
-        else:
-            return (
-                np.all(self.r == rhs.r) and np.all(self.v == rhs.v) and np.all(self.mu == rhs.mu) and np.all(self.t == rhs.t) and np.all([np.all(self.propkw[k] == rhs.propkw[k]) for k in self.propkw]))
+        if self.propkw.keys() != rhs.propkw.keys():
+            return False
+        return (
+            np.all(self.r == rhs.r)
+            and np.all(self.v == rhs.v)
+            and np.all(self.mu == rhs.mu)
+            and np.all(self.t == rhs.t)
+            and all(
+                np.array_equal(
+                    np.asarray(self.propkw[key]),
+                    np.asarray(rhs.propkw[key]),
+                )
+                for key in self.propkw
+            )
+        )
 
     @classmethod
     def fromEquinoctialElements(

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1785,6 +1785,7 @@ def test_orbit_equality_and_hash_respect_propkw_mapping():
     assert second == first
     assert hash(first) == hash(second)
     assert isinstance(hash(with_area), int)
+    assert plain.__eq__(object()) is NotImplemented
 
 
 def test_orbit_mixed_vector_bound_unbound_regression():

--- a/tests/test_orbit.py
+++ b/tests/test_orbit.py
@@ -1766,6 +1766,27 @@ def test_orbit_scalar_vector_api_branches_and_reprs(tmp_path):
     assert "propagator=" in repr(orbital_observer)
 
 
+def test_orbit_equality_and_hash_respect_propkw_mapping():
+    r = np.array([7.0e6, 0.0, 0.0])
+    v = np.array([0.0, 7.5e3, 0.0])
+
+    plain = ssapy.Orbit(r, v, 0.0)
+    with_area = ssapy.Orbit(r, v, 0.0, propkw={"area": 2.0})
+    assert plain != with_area
+    assert with_area != plain
+
+    first = ssapy.Orbit(
+        r, v, 0.0, propkw={"area": 2.0, "mass": np.array([5.0])}
+    )
+    second = ssapy.Orbit(
+        r, v, 0.0, propkw={"mass": np.array([5.0]), "area": 2.0}
+    )
+    assert first == second
+    assert second == first
+    assert hash(first) == hash(second)
+    assert isinstance(hash(with_area), int)
+
+
 def test_orbit_mixed_vector_bound_unbound_regression():
     a = np.array([7.0e6, -1.0e7])
     e = np.array([0.1, 1.5])


### PR DESCRIPTION
## Summary

Make `Orbit` equality and hashing consistent for propagation keyword mappings.

## Changes

- Require matching `propkw` key sets before comparing values.
- Return `NotImplemented` when comparing an `Orbit` with an unrelated type.
- Hash `propkw` entries in sorted-key order so insertion order does not affect identity.
- Canonicalise scalar and array `propkw` values before hashing, allowing ordinary scalar values such as `area=2.0`.
- Add regression coverage for asymmetric key sets, reversed comparisons, reordered mappings, and scalar hashing.

## Testing

- `python3 -m py_compile ssapy/orbit.py tests/test_orbit.py`
- `git diff --check`

The local environment does not have the SSAPy pytest dependency stack installed, so the repository CI will provide the full test run.

Fixes #139
