### PR TITLE
Fix Particles fuse negligible-weight status

### DIFF
--- a/ssapy/particles.py
+++ b/ssapy/particles.py
@@ -255,7 +255,7 @@ class Particles:
         # Update the weight values by 'cross-pollinating' epoch likelihoods
         status = self.reweight(epoch_particles)
         # Check that we have at least some non-zero weights for particles
-        if status > 0 and verbose:
+        if not status and verbose:
             print("All weights are negligible in Particles class")
             print("\tlog-norm:",np.logaddexp.reduce(self.ln_wts))
         # Resample the weights to maintain only significant particles

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -186,4 +186,8 @@ def test_particles_resample_over_request_and_verbose_fuse(monkeypatch, capsys):
     monkeypatch.setattr(particles, "reweight", lambda epoch_particles: True)
     monkeypatch.setattr(particles, "resample", lambda num_particles: None)
     particles.fuse(particles, verbose=True)
+    assert "All weights are negligible" not in capsys.readouterr().out
+
+    monkeypatch.setattr(particles, "reweight", lambda epoch_particles: False)
+    particles.fuse(particles, verbose=True)
     assert "All weights are negligible" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Fix the inverted verbose-status check in `Particles.fuse()`.

## Changes

- Emit the negligible-weight warning only when `reweight()` reports failure.
- Update the existing regression test to verify that successful reweighting is silent.
- Add the corresponding failure-path assertion so the warning remains covered.

## Testing

- `python3 -m py_compile ssapy/particles.py tests/test_particles.py`
- `git diff --check`

The local environment does not have the full SSAPy pytest dependency stack installed, so repository CI will provide the full test run.

Fixes #141
